### PR TITLE
Add build versioning, cache busting, and version bump script

### DIFF
--- a/SMED V03.html
+++ b/SMED V03.html
@@ -3,6 +3,9 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
+<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+<meta http-equiv="Pragma" content="no-cache" />
+<meta http-equiv="Expires" content="0" />
 <title>SMED L29 – Suivi changement de PO</title>
 <style>
 :root {
@@ -1138,6 +1141,8 @@ summary { cursor:pointer; }
 <div class="toast-container" id="toastContainer" aria-live="polite"></div>
 <script>
 (() => {
+  // --- Version de build (à mettre à jour à chaque nouvelle release) ---
+  const APP_VERSION = '2025-10-01_v03';
   const STORAGE_KEY = 'smed_timer_v3';
   const SCHEMA_VERSION = 5;
   const phasesList = ['Activité CHGT de PO','Début de PO','Fin de PO','Vide de ligne'];
@@ -1266,7 +1271,37 @@ summary { cursor:pointer; }
     splash: document.getElementById('splash')
   };
 
+  // --- Cache-buster images pour refléter la build courante ---
+  (function cacheBustImages(){
+    try {
+      const stamp = encodeURIComponent(APP_VERSION);
+      document.querySelectorAll('img.logo-image').forEach(img => {
+        const u = new URL(img.getAttribute('src'), location.href);
+        u.searchParams.set('v', stamp);
+        img.setAttribute('src', u.toString());
+      });
+    } catch (_) {}
+  })();
+
   let state = migrate(loadState());
+  // --- Purge automatique si la version de build change ---
+  try {
+    const stored = (state && typeof state === 'object') ? state.app_version : null;
+    if (stored !== APP_VERSION) {
+      try { localStorage.removeItem(STORAGE_KEY); } catch(_) {}
+      state = DEFAULT_STATE();
+      state.app_version = APP_VERSION;
+      saveState(false); // ne pas afficher de toast ici
+    } else {
+      state.app_version = APP_VERSION;
+    }
+  } catch (_) {
+    // En cas de souci, on repart propre
+    try { localStorage.removeItem(STORAGE_KEY); } catch(__) {}
+    state = DEFAULT_STATE();
+    state.app_version = APP_VERSION;
+    saveState(false);
+  }
   const runtime = {
     activePage: 'timerPage',
     animationFrame: null,
@@ -1381,6 +1416,7 @@ summary { cursor:pointer; }
         copy.completedOpsByOp[op][ph] = Array.from(state.completedOpsByOp[op][ph]);
       });
     });
+    copy.app_version = APP_VERSION;
     return copy;
   }
 

--- a/bump-version.js
+++ b/bump-version.js
@@ -1,0 +1,58 @@
+// bump-version.js
+// Usage: node bump-version.js "SMED V03.html"
+// Effet: crée "SMED V04.html" + met à jour APP_VERSION à la date du jour et suffix v04
+
+const fs = require('fs');
+const path = require('path');
+
+function pad2(n){ return String(n).padStart(2,'0'); }
+
+function nextFileName(current) {
+  const m = current.match(/^(.+?\sV)(\d+)(\.html)$/i);
+  if (!m) throw new Error('Nom attendu au format "SMED VNN.html"');
+  const base = m[1];
+  const n = parseInt(m[2],10);
+  const ext = m[3];
+  const next = pad2(n+1);
+  return base + next + ext; // ex: SMED V03.html -> SMED V04.html
+}
+
+function makeAppVersionSuffix(nextFile){
+  const today = new Date();
+  const yyyy = today.getFullYear();
+  const mm = pad2(today.getMonth()+1);
+  const dd = pad2(today.getDate());
+  // extraire NN depuis "VNN"
+  const m = nextFile.match(/V(\d+)\.html$/i);
+  const vnn = m ? 'v' + m[1] : 'vXX';
+  return `${yyyy}-${mm}-${dd}_${vnn}`;
+}
+
+function replaceAppVersion(content, newVer){
+  // remplace la ligne const APP_VERSION = '...';
+  const re = /const\s+APP_VERSION\s*=\s*['"][^'"]*['"]\s*;/;
+  if (!re.test(content)) {
+    throw new Error('APP_VERSION introuvable : ajoute d’abord const APP_VERSION = "..."; dans le HTML');
+  }
+  return content.replace(re, `const APP_VERSION = '${newVer}';`);
+}
+
+(function main(){
+  const current = process.argv[2];
+  if (!current) throw new Error('Indique le fichier courant: node bump-version.js "SMED V03.html"');
+
+  const currPath = path.resolve(process.cwd(), current);
+  if (!fs.existsSync(currPath)) throw new Error('Fichier introuvable: ' + currPath);
+
+  const nextName = nextFileName(path.basename(currPath));
+  const nextPath = path.join(path.dirname(currPath), nextName);
+
+  const html = fs.readFileSync(currPath, 'utf8');
+  const newVer = makeAppVersionSuffix(nextName);
+  const patched = replaceAppVersion(html, newVer);
+
+  fs.writeFileSync(nextPath, patched, 'utf8');
+
+  console.log('OK → Nouveau fichier :', nextName);
+  console.log('APP_VERSION =', newVer);
+})();


### PR DESCRIPTION
## Summary
- add an APP_VERSION constant with automatic state purge and cache-busted logos
- include anti-cache meta tags in the HTML head to reduce stale caching
- provide a bump-version.js helper to duplicate the HTML with an updated filename and APP_VERSION

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd669c8d34832db953f286ca3503fd