### PR TITLE
Add operator sorting and grouping tools to phase parameters

### DIFF
--- a/SMED V03.html
+++ b/SMED V03.html
@@ -675,6 +675,79 @@ tfoot td { font-weight:700; }
 .param-table tbody tr.dragging { opacity:.4; }
 .row-tools { display:flex; gap:8px; }
 .batch-actions { display:flex; flex-wrap:wrap; gap:10px; }
+.phase-toolbar {
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+  align-items:center;
+  padding:12px;
+  border-bottom:1px solid rgba(255,255,255,.05);
+  background:rgba(9,18,40,.55);
+  position:sticky;
+  top:0;
+  z-index:2;
+}
+.phase-toolbar .phase-toolbar-group {
+  display:flex;
+  gap:8px;
+  align-items:center;
+}
+.phase-toolbar .phase-toolbar-group label {
+  font-size:0.85rem;
+  color:var(--muted);
+}
+.phase-toolbar select {
+  min-width:200px;
+  padding:8px 12px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,.18);
+  background:rgba(15,26,52,.85);
+}
+.phase-filter-chips {
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px;
+  align-items:center;
+}
+.phase-filter-chip {
+  border:1px solid rgba(255,255,255,.12);
+  border-radius:999px;
+  padding:6px 12px;
+  background:transparent;
+  color:inherit;
+  cursor:pointer;
+  font-size:0.85rem;
+  transition:background .2s ease, border-color .2s ease;
+}
+.phase-filter-chip.active {
+  background:var(--accent);
+  color:#021221;
+  border-color:transparent;
+}
+.phase-toolbar-toggle {
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  font-size:0.85rem;
+  color:var(--muted);
+}
+.phase-toolbar-toggle input {
+  width:18px;
+  height:18px;
+}
+.param-table tbody tr.is-filtered {
+  display:none;
+}
+.param-table tbody tr.op-group-header-row td {
+  padding-top:16px;
+  padding-bottom:6px;
+}
+.op-group-header {
+  font-size:0.8rem;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+  opacity:0.8;
+}
 .import-group {
   display:inline-flex;
   align-items:center;
@@ -1277,6 +1350,8 @@ summary { cursor:pointer; }
     shouldScrollToCurrent: false,
     quickEventMenu: null
   };
+  const phaseUiState = new Map();
+  const phaseSections = new Map();
 
   function loadState() {
     try {
@@ -1473,6 +1548,57 @@ summary { cursor:pointer; }
 
   function getCurrentOperatorName(index) {
     return state.operators[index] || `Opérateur ${index+1}`;
+  }
+
+  function getPhaseStateConfig(phase) {
+    if (!phaseUiState.has(phase)) {
+      phaseUiState.set(phase, {
+        sortMode: 'none',
+        filterOperator: null,
+        allowCrossAssign: false
+      });
+    }
+    return phaseUiState.get(phase);
+  }
+
+  function normalizeOperatorIndex(value) {
+    if (!Number.isFinite(value)) return Math.max(0, Math.min(state.operators.length - 1, state.defaultOperatorIndex || 0));
+    const normalized = Math.floor(value);
+    if (normalized < 0) return 0;
+    if (normalized >= state.operators.length) return Math.max(0, state.operators.length - 1);
+    return normalized;
+  }
+
+  function formatOperatorName(index) {
+    const normalized = normalizeOperatorIndex(index);
+    return state.operators[normalized] || `Opérateur n°${normalized + 1}`;
+  }
+
+  function stableSortByOperatorIndex(ops, asc = true) {
+    const mapped = ops.map((op, idx) => ({ op, idx }));
+    mapped.sort((a, b) => {
+      const aIdx = normalizeOperatorIndex(a.op.operatorIndex);
+      const bIdx = normalizeOperatorIndex(b.op.operatorIndex);
+      if (aIdx === bIdx) return a.idx - b.idx;
+      return asc ? aIdx - bIdx : bIdx - aIdx;
+    });
+    return mapped.map(item => item.op);
+  }
+
+  function groupByOperatorIndex(ops) {
+    const groups = new Map();
+    ops.forEach(op => {
+      const idx = normalizeOperatorIndex(op.operatorIndex);
+      if (!groups.has(idx)) groups.set(idx, []);
+      groups.get(idx).push(op);
+    });
+    return groups;
+  }
+
+  function applyPhaseFilterForOperator(ops, operatorIndex = null) {
+    if (operatorIndex == null) return ops.slice();
+    const normalized = normalizeOperatorIndex(operatorIndex);
+    return ops.filter(op => normalizeOperatorIndex(op.operatorIndex) === normalized);
   }
 
   // PATCH SMED — stats opérateur/phase
@@ -2484,6 +2610,7 @@ ${buildReportHtml()}
 
   function buildPhaseTables() {
     els.phaseTables.innerHTML = '';
+    phaseSections.clear();
     phasesList.forEach(phase => {
       const section = document.createElement('section');
       section.className = 'section-group';
@@ -2500,6 +2627,7 @@ ${buildReportHtml()}
             <button type="button" class="ghost" data-phase="${phase}" data-action="export-json">Exporter JSON</button>
           </div>
           <div class="phase-table-wrapper">
+            <div class="phase-toolbar" data-phase-toolbar></div>
             <table class="param-table" data-phase="${phase}">
               <thead>
                 <tr><th title="Inclure cette opération dans le SMED (décocher si non applicable)">Incluse ?</th><th>Opération</th><th>Temps cible (min)</th><th>Opérateur</th><th>Détails (optionnel)</th><th></th></tr>
@@ -2511,11 +2639,12 @@ ${buildReportHtml()}
         </details>
       `;
       els.phaseTables.appendChild(section);
+      const toolbar = section.querySelector('[data-phase-toolbar]');
       const tbody = section.querySelector('tbody');
       const table = section.querySelector('table');
-      (state.phases[phase] || []).forEach((operation, index) => {
-        tbody.appendChild(buildPhaseRow(phase, operation, index));
-      });
+      phaseSections.set(phase, { section, table, tbody, toolbar });
+      renderPhaseToolbar(phase);
+      renderPhaseTableBody(phase);
       updatePhaseTotal(table, phase);
       section.addEventListener('change', handlePhaseInputChange);
       section.querySelectorAll('button[data-phase]').forEach(btn => btn.addEventListener('click', handlePhaseAction));
@@ -2525,12 +2654,174 @@ ${buildReportHtml()}
     });
   }
 
+  function renderPhaseToolbar(phase) {
+    const refs = phaseSections.get(phase);
+    if (!refs || !refs.toolbar) return;
+    const toolbar = refs.toolbar;
+    const config = getPhaseStateConfig(phase);
+    const ops = state.phases[phase] || [];
+    const disabled = ops.length === 0;
+    toolbar.innerHTML = '';
+
+    const sortGroup = document.createElement('div');
+    sortGroup.className = 'phase-toolbar-group';
+    const sortLabel = document.createElement('span');
+    sortLabel.textContent = 'Trier';
+    sortGroup.appendChild(sortLabel);
+    const sortSelect = document.createElement('select');
+    sortSelect.setAttribute('aria-label', 'Trier les opérations de la phase par opérateur');
+    sortSelect.innerHTML = [
+      { value: 'none', label: 'Aucun' },
+      { value: 'op-asc', label: 'Opérateur A→Z' },
+      { value: 'op-desc', label: 'Opérateur Z→A' },
+      { value: 'group', label: 'Regrouper par opérateur' }
+    ].map(option => `<option value="${option.value}">${option.label}</option>`).join('');
+    sortSelect.value = config.sortMode;
+    sortSelect.disabled = disabled;
+    sortSelect.addEventListener('change', event => {
+      config.sortMode = event.target.value;
+      if (config.sortMode !== 'group') {
+        config.allowCrossAssign = false;
+      }
+      refreshPhaseTable(phase);
+    });
+    sortGroup.appendChild(sortSelect);
+    toolbar.appendChild(sortGroup);
+
+    const filterWrapper = document.createElement('div');
+    filterWrapper.className = 'phase-toolbar-group';
+    const filterLabel = document.createElement('span');
+    filterLabel.textContent = 'Filtrer';
+    filterWrapper.appendChild(filterLabel);
+    const chips = document.createElement('div');
+    chips.className = 'phase-filter-chips';
+    const allChip = document.createElement('button');
+    allChip.type = 'button';
+    allChip.className = `phase-filter-chip${config.filterOperator == null ? ' active' : ''}`;
+    allChip.textContent = 'Tous';
+    allChip.disabled = disabled;
+    allChip.addEventListener('click', () => {
+      if (config.filterOperator == null) return;
+      config.filterOperator = null;
+      refreshPhaseTable(phase);
+    });
+    chips.appendChild(allChip);
+    state.operators.forEach((op, idx) => {
+      const chip = document.createElement('button');
+      chip.type = 'button';
+      chip.className = `phase-filter-chip${config.filterOperator != null && normalizeOperatorIndex(config.filterOperator) === normalizeOperatorIndex(idx) ? ' active' : ''}`;
+      chip.textContent = op || `Opérateur n°${idx + 1}`;
+      chip.disabled = disabled;
+      chip.addEventListener('click', () => {
+        const normalized = normalizeOperatorIndex(idx);
+        if (config.filterOperator != null && normalizeOperatorIndex(config.filterOperator) === normalized) {
+          config.filterOperator = null;
+        } else {
+          config.filterOperator = normalized;
+        }
+        refreshPhaseTable(phase);
+      });
+      chips.appendChild(chip);
+    });
+    filterWrapper.appendChild(chips);
+    toolbar.appendChild(filterWrapper);
+
+    const toggleLabel = document.createElement('label');
+    toggleLabel.className = 'phase-toolbar-toggle';
+    const toggleInput = document.createElement('input');
+    toggleInput.type = 'checkbox';
+    toggleInput.checked = !!config.allowCrossAssign;
+    toggleInput.disabled = disabled || config.sortMode !== 'group';
+    toggleInput.setAttribute('aria-label', 'Autoriser le déplacement entre opérateurs (réassignation)');
+    toggleInput.addEventListener('change', event => {
+      config.allowCrossAssign = event.target.checked;
+      refreshPhaseTable(phase);
+    });
+    toggleLabel.appendChild(toggleInput);
+    const toggleText = document.createElement('span');
+    toggleText.textContent = 'Autoriser les déplacements entre opérateurs (réassigne)';
+    toggleLabel.appendChild(toggleText);
+    toolbar.appendChild(toggleLabel);
+  }
+
+  function renderPhaseTableBody(phase) {
+    const refs = phaseSections.get(phase);
+    if (!refs) return;
+    const tbody = refs.tbody;
+    const table = refs.table;
+    if (!tbody || !table) return;
+    const config = getPhaseStateConfig(phase);
+    const operations = (state.phases[phase] || []).slice();
+    let ordered = operations.slice();
+    if (config.sortMode === 'op-asc') {
+      ordered = stableSortByOperatorIndex(operations, true);
+    } else if (config.sortMode === 'op-desc') {
+      ordered = stableSortByOperatorIndex(operations, false);
+    } else if (config.sortMode === 'group') {
+      ordered = stableSortByOperatorIndex(operations, true);
+    }
+    ordered.forEach(operation => {
+      if (!operation.id) operation.id = newId();
+    });
+    const filterIndex = config.filterOperator == null ? null : normalizeOperatorIndex(config.filterOperator);
+    const visibleOps = new Set(applyPhaseFilterForOperator(ordered, filterIndex).map(op => op.id));
+    tbody.innerHTML = '';
+    table.dataset.sortMode = config.sortMode;
+    if (!ordered.length) {
+      return;
+    }
+    if (config.sortMode === 'group') {
+      const groups = groupByOperatorIndex(ordered);
+      groups.forEach((items, operatorIndex) => {
+        const headerRow = document.createElement('tr');
+        headerRow.className = 'op-group-header-row';
+        headerRow.dataset.kind = 'group-header';
+        headerRow.dataset.operatorIndex = operatorIndex;
+        const cell = document.createElement('td');
+        cell.colSpan = 6;
+        cell.className = 'op-group-header';
+        cell.setAttribute('role', 'rowheader');
+        cell.textContent = `Opérateur : ${formatOperatorName(operatorIndex)}`;
+        headerRow.appendChild(cell);
+        if (filterIndex != null && filterIndex !== normalizeOperatorIndex(operatorIndex)) {
+          headerRow.classList.add('is-filtered');
+        }
+        tbody.appendChild(headerRow);
+        items.forEach(operation => {
+          const row = buildPhaseRow(phase, operation);
+          if (!visibleOps.has(operation.id)) {
+            row.classList.add('is-filtered');
+          }
+          tbody.appendChild(row);
+        });
+      });
+    } else {
+      ordered.forEach(operation => {
+        const row = buildPhaseRow(phase, operation);
+        if (!visibleOps.has(operation.id)) {
+          row.classList.add('is-filtered');
+        }
+        tbody.appendChild(row);
+      });
+    }
+  }
+
+  function refreshPhaseTable(phase) {
+    const refs = phaseSections.get(phase);
+    if (!refs) return;
+    renderPhaseToolbar(phase);
+    renderPhaseTableBody(phase);
+    updatePhaseTotal(refs.table, phase);
+  }
+
   function buildPhaseRow(phase, operation, index) {
     const tr = document.createElement('tr');
     tr.draggable = true;
     const opId = operation.id || newId();
     operation.id = opId;
     tr.dataset.id = opId;
+    tr.dataset.kind = 'operation';
+    tr.dataset.operatorIndex = normalizeOperatorIndex(operation.operatorIndex);
     const enabled = operation.enabled !== false;
     operation.enabled = enabled;
     tr.innerHTML = `
@@ -2544,8 +2835,10 @@ ${buildReportHtml()}
     const select = tr.querySelector('select');
     populateOperatorSelect(select, operation.operatorIndex);
     tr.querySelector('[data-action="delete"]').addEventListener('click', () => {
-      const idx = Array.from(tr.parentElement.children).indexOf(tr);
-      state.phases[phase].splice(idx,1);
+      const idx = state.phases[phase].findIndex(item => item.id === opId);
+      if (idx >= 0) {
+        state.phases[phase].splice(idx,1);
+      }
       saveState(true);
       buildPhaseTables();
       renderOperatorColumns();
@@ -2572,9 +2865,11 @@ ${buildReportHtml()}
     const row = input.closest('tr');
     if (!row) return;
     const phase = input.closest('table').dataset.phase;
-    const idx = Array.from(row.parentElement.children).indexOf(row);
     const field = input.dataset.field;
-    if (!field) return;
+    const opId = row.dataset.id;
+    if (!field || !opId) return;
+    const idx = state.phases[phase].findIndex(item => item.id === opId);
+    if (idx < 0) return;
     if (field === 'enabled') {
       state.phases[phase][idx].enabled = input.checked;
       saveState();
@@ -2592,6 +2887,23 @@ ${buildReportHtml()}
       const numeric = Number(input.value);
       if (field === 'operatorIndex') {
         state.phases[phase][idx][field] = Number.isFinite(numeric) ? numeric : state.defaultOperatorIndex;
+        row.dataset.operatorIndex = normalizeOperatorIndex(state.phases[phase][idx][field]);
+        saveState();
+        updatePhaseTotal(input.closest('table'), phase);
+        updateTargets();
+        renderOperatorColumns();
+        updateAnalysisDelayed();
+        const selectionStart = typeof input.selectionStart === 'number' ? input.selectionStart : null;
+        const selectionEnd = typeof input.selectionEnd === 'number' ? input.selectionEnd : null;
+        refreshPhaseTable(phase);
+        const refreshedInput = els.phaseTables.querySelector(`tr[data-id="${opId}"] [data-field="operatorIndex"]`);
+        if (refreshedInput) {
+          refreshedInput.focus({ preventScroll: true });
+          if (selectionStart != null && selectionEnd != null && refreshedInput.setSelectionRange) {
+            refreshedInput.setSelectionRange(selectionStart, selectionEnd);
+          }
+        }
+        return;
       } else {
         state.phases[phase][idx][field] = Number.isFinite(numeric) ? numeric : 0;
       }
@@ -2625,8 +2937,12 @@ ${buildReportHtml()}
       const idx = Number(operator) - 1;
       if (!Number.isInteger(idx) || idx < 0 || idx > 3) return;
       selected.forEach(row => {
-        const rowIndex = Array.from(row.parentElement.children).indexOf(row);
-        state.phases[phase][rowIndex].operatorIndex = idx;
+        const opId = row.dataset.id;
+        if (!opId) return;
+        const rowIndex = state.phases[phase].findIndex(op => op.id === opId);
+        if (rowIndex >= 0) {
+          state.phases[phase][rowIndex].operatorIndex = idx;
+        }
       });
       saveState();
       buildPhaseTables();
@@ -2636,8 +2952,12 @@ ${buildReportHtml()}
       const value = Number(prompt('Temps cible (min) :', 1));
       if (!Number.isFinite(value)) return;
       selected.forEach(row => {
-        const rowIndex = Array.from(row.parentElement.children).indexOf(row);
-        state.phases[phase][rowIndex].targetMin = value;
+        const opId = row.dataset.id;
+        if (!opId) return;
+        const rowIndex = state.phases[phase].findIndex(op => op.id === opId);
+        if (rowIndex >= 0) {
+          state.phases[phase][rowIndex].targetMin = value;
+        }
       });
       saveState();
       buildPhaseTables();
@@ -2718,48 +3038,160 @@ ${buildReportHtml()}
   }
 
   function enableDragAndDrop(tbody, phase) {
-    let dragged;
+    let dragged = null;
+    let initialOrder = [];
+
+    const getGroupAnchors = operatorIndex => {
+      const normalized = normalizeOperatorIndex(Number(operatorIndex));
+      const headers = Array.from(tbody.querySelectorAll('tr[data-kind="group-header"]')).filter(row => !row.classList.contains('is-filtered'));
+      const header = headers.find(row => normalizeOperatorIndex(Number(row.dataset.operatorIndex)) === normalized) || null;
+      let nextHeader = null;
+      if (header) {
+        let sibling = header.nextElementSibling;
+        while (sibling) {
+          if (sibling.dataset.kind === 'group-header') {
+            nextHeader = sibling;
+            break;
+          }
+          sibling = sibling.nextElementSibling;
+        }
+      }
+      return { header, nextHeader };
+    };
+
     tbody.addEventListener('dragstart', event => {
-      dragged = event.target;
-      dragged.classList.add('dragging');
+      const row = event.target.closest('tr[data-kind="operation"]');
+      if (!row) return;
+      dragged = row;
+      initialOrder = state.phases[phase].map(op => op.id);
+      row.classList.add('dragging');
       event.dataTransfer.effectAllowed = 'move';
     });
-    tbody.addEventListener('dragend', event => {
-      event.target.classList.remove('dragging');
+
+    tbody.addEventListener('dragend', () => {
+      if (dragged) {
+        dragged.classList.remove('dragging');
+      }
       dragged = null;
+      initialOrder = [];
     });
+
     tbody.addEventListener('dragover', event => {
+      if (!dragged) return;
+      const config = getPhaseStateConfig(phase);
+      const draggedOperator = normalizeOperatorIndex(Number(dragged.dataset.operatorIndex));
+      if (config.sortMode === 'group' && !config.allowCrossAssign) {
+        const { header, nextHeader } = getGroupAnchors(draggedOperator);
+        const pointerY = event.clientY;
+        const boundsTop = header ? header.getBoundingClientRect().bottom : tbody.getBoundingClientRect().top;
+        const boundsBottom = nextHeader ? nextHeader.getBoundingClientRect().top : tbody.getBoundingClientRect().bottom;
+        if (pointerY < boundsTop || pointerY > boundsBottom) {
+          event.dataTransfer.dropEffect = 'none';
+          return;
+        }
+        const targetRow = event.target.closest('tr');
+        if (targetRow) {
+          const kind = targetRow.dataset.kind;
+          const targetOperator = normalizeOperatorIndex(Number(targetRow.dataset.operatorIndex));
+          if ((kind === 'operation' || kind === 'group-header') && targetOperator !== draggedOperator) {
+            event.dataTransfer.dropEffect = 'none';
+            return;
+          }
+        }
+      }
+      let selector = 'tr[data-kind="operation"]:not(.dragging):not(.is-filtered)';
+      if (config.sortMode === 'group' && !config.allowCrossAssign) {
+        selector += `[data-operator-index="${draggedOperator}"]`;
+      }
+      const after = getDragAfterElement(tbody, event.clientY, selector);
       event.preventDefault();
-      const after = getDragAfterElement(tbody, event.clientY);
+      event.dataTransfer.dropEffect = 'move';
       if (!after) {
-        tbody.appendChild(dragged);
+        if (config.sortMode === 'group' && !config.allowCrossAssign) {
+          const { nextHeader } = getGroupAnchors(draggedOperator);
+          if (nextHeader) {
+            tbody.insertBefore(dragged, nextHeader);
+          } else {
+            tbody.appendChild(dragged);
+          }
+        } else {
+          tbody.appendChild(dragged);
+        }
       } else {
         tbody.insertBefore(dragged, after);
       }
     });
-    tbody.addEventListener('drop', () => {
-      const rows = Array.from(tbody.querySelectorAll('tr'));
-      state.phases[phase] = rows.map(row => {
-        const enabledInput = row.querySelector('input[data-field="enabled"]');
-        const detailsInput = row.querySelector('[data-field="details"]');
+
+    tbody.addEventListener('drop', event => {
+      if (!dragged) return;
+      event.preventDefault();
+      const draggedId = dragged.dataset.id;
+      const config = getPhaseStateConfig(phase);
+      const allowCrossAssign = config.sortMode === 'group' && config.allowCrossAssign;
+      const previousIndices = new Map(state.phases[phase].map(op => [op.id, normalizeOperatorIndex(op.operatorIndex)]));
+      const orderElements = [];
+      let currentOperator = null;
+      Array.from(tbody.children).forEach(child => {
+        if (child.dataset.kind === 'group-header') {
+          currentOperator = normalizeOperatorIndex(Number(child.dataset.operatorIndex));
+        } else if (child.dataset.kind === 'operation') {
+          let effectiveOperator = normalizeOperatorIndex(Number(child.dataset.operatorIndex));
+          if (config.sortMode === 'group' && currentOperator != null) {
+            if (allowCrossAssign) {
+              effectiveOperator = currentOperator;
+            }
+          }
+          orderElements.push({ element: child, operatorIndex: effectiveOperator });
+        }
+      });
+      let reassigned = false;
+      const newState = orderElements.map(({ element, operatorIndex }) => {
+        const normalizedOperator = normalizeOperatorIndex(operatorIndex);
+        const previousOperator = previousIndices.get(element.dataset.id);
+        if (allowCrossAssign && previousOperator != null && previousOperator !== normalizedOperator) {
+          reassigned = true;
+        }
+        element.dataset.operatorIndex = normalizedOperator;
+        const select = element.querySelector('select[data-field="operatorIndex"]');
+        if (select && select.value !== String(normalizedOperator)) {
+          select.value = normalizedOperator;
+        }
+        const enabledInput = element.querySelector('input[data-field="enabled"]');
+        const detailsInput = element.querySelector('[data-field="details"]');
         return {
-          id: row.dataset.id || newId(),
-          name: row.querySelector('input[data-field="name"]').value,
-          targetMin: Number(row.querySelector('input[data-field="targetMin"]').value) || 0,
-          operatorIndex: Number(row.querySelector('select[data-field="operatorIndex"]').value),
+          id: element.dataset.id || newId(),
+          name: element.querySelector('input[data-field="name"]').value,
+          targetMin: Number(element.querySelector('input[data-field="targetMin"]').value) || 0,
+          operatorIndex: normalizedOperator,
           enabled: enabledInput ? enabledInput.checked : true,
           details: detailsInput ? detailsInput.value : ''
         };
       });
+      const newOrderIds = newState.map(op => op.id);
+      const reordered = newOrderIds.length === initialOrder.length && newOrderIds.some((id, idx) => id !== initialOrder[idx]);
+      dragged.classList.remove('dragging');
+      dragged = null;
+      initialOrder = [];
+      state.phases[phase] = newState;
       saveState();
       renderOperatorColumns();
       updateTargets();
       updateAnalysisDelayed();
+      refreshPhaseTable(phase);
+      if (reassigned) {
+        const moved = newState.find(op => op.id === draggedId);
+        const targetName = moved ? formatOperatorName(moved.operatorIndex) : formatOperatorName(state.defaultOperatorIndex);
+        showToast(`Opération réassignée à ${targetName} ✓`);
+      }
+      if (reordered) {
+        showToast('Ordre mis à jour ✓');
+      }
     });
   }
 
-  function getDragAfterElement(container, y) {
-    const draggableElements = [...container.querySelectorAll('tr:not(.dragging)')];
+  function getDragAfterElement(container, y, selector = 'tr[data-kind="operation"]:not(.dragging):not(.is-filtered)') {
+    const draggableElements = [...container.querySelectorAll(selector)];
+    if (!draggableElements.length) return null;
     return draggableElements.reduce((closest, child) => {
       const box = child.getBoundingClientRect();
       const offset = y - box.top - box.height / 2;
@@ -2768,7 +3200,7 @@ ${buildReportHtml()}
       } else {
         return closest;
       }
-    }, { offset: Number.NEGATIVE_INFINITY }).element;
+    }, { offset: Number.NEGATIVE_INFINITY, element: null }).element;
   }
 
   function buildDefaultsForm() {

--- a/SMED V04.html
+++ b/SMED V04.html
@@ -1,0 +1,4094 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>SMED L29 – Suivi changement de PO</title>
+<style>
+:root {
+  --bg:#0f1a34;
+  --panel:#172447;
+  --fg:#e8eefc;
+  --accent:#3ddc97;
+  --warn:#ffb703;
+  --danger:#ef476f;
+  --muted:#7b87a6;
+  --shadow:0 20px 40px rgba(7,14,33,.55);
+  --radius-xl:28px;
+  --radius-lg:20px;
+  --radius:14px;
+  --radius-sm:10px;
+  --focus:0 0 0 3px rgba(61,220,151,.35);
+  color-scheme:dark;
+}
+* { box-sizing:border-box; }
+html,body { height:100%; }
+body {
+  margin:0;
+  font-family:"Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background:radial-gradient(140% 140% at 50% 0%,#1a2b55 0%,#0f1a34 45%,#09112a 100%);
+  color:var(--fg);
+}
+body.splash-lock { overflow:hidden; }
+button,input,select,textarea { font:inherit; color:inherit; }
+button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible, a:focus-visible {
+  outline:3px solid var(--accent);
+  outline-offset:2px;
+}
+.app {
+  min-height:100%;
+  display:grid;
+  grid-template-rows:auto 1fr;
+}
+header {
+  padding:20px clamp(16px,3vw,40px) 0;
+}
+.top-nav {
+  display:flex;
+  flex-wrap:wrap;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+}
+.header-actions {
+  display:flex;
+  flex-wrap:wrap;
+  align-items:center;
+  gap:12px;
+  margin-left:auto;
+}
+.brand {
+  display:inline-flex;
+  align-items:center;
+  gap:12px;
+  font-weight:700;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+  color:var(--fg);
+}
+.brand-sep {
+  width:1px;
+  height:28px;
+  background:rgba(232,238,252,.35);
+}
+.brand-line {
+  font-size:1rem;
+  letter-spacing:0.12em;
+}
+.nav-tabs {
+  display:flex;
+  gap:12px;
+  margin-left:56px;
+}
+.nav-tabs button {
+  background:transparent;
+  border:1px solid rgba(255,255,255,.12);
+  color:var(--fg);
+  border-radius:999px;
+  padding:10px 18px;
+  cursor:pointer;
+  transition:background .2s ease, transform .2s ease, border-color .2s ease;
+  min-width:120px;
+}
+.nav-tabs button.active {
+  background:var(--accent);
+  color:#021221;
+  border-color:transparent;
+  transform:translateY(-1px);
+}
+main {
+  padding:0 clamp(16px,3vw,40px) 40px;
+  display:grid;
+}
+.page {
+  display:none;
+}
+.page.active {
+  display:grid;
+  gap:24px;
+}
+.timer-grid {
+  display:grid;
+  gap:24px;
+}
+@media (min-width:1200px) {
+  .timer-grid {
+    grid-template-columns: minmax(0,1fr) 360px;
+  }
+}
+body.journal-hidden #journalAside {
+  display:none;
+}
+body.journal-hidden .timer-grid {
+  grid-template-columns:1fr !important;
+}
+.panel {
+  background:rgba(23,36,71,.86);
+  border:1px solid rgba(255,255,255,.06);
+  border-radius:var(--radius-xl);
+  padding:24px;
+  box-shadow:var(--shadow);
+  backdrop-filter:blur(16px);
+}
+.panel.compact { padding:18px; border-radius:var(--radius-lg); }
+.panel-title {
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  gap:16px;
+  margin-bottom:18px;
+}
+.panel-title h2 {
+  margin:0;
+  font-size:1.1rem;
+  letter-spacing:.02em;
+}
+.grid-two {
+  display:grid;
+  gap:16px;
+}
+@media (min-width:840px) {
+  .grid-two {
+    grid-template-columns:repeat(2,minmax(0,1fr));
+  }
+}
+.id-row {
+  display:grid;
+  gap:12px;
+  grid-template-columns:repeat(auto-fit,minmax(180px,1fr));
+}
+.field label {
+  display:grid;
+  gap:6px;
+  font-size:0.76rem;
+  text-transform:uppercase;
+  letter-spacing:0.08em;
+  color:var(--muted);
+}
+.field input, .field select {
+  border-radius:var(--radius);
+  border:1px solid rgba(255,255,255,.12);
+  background:rgba(15,26,52,.65);
+  padding:12px 14px;
+  min-height:48px;
+}
+.field input[readonly] {
+  opacity:.7;
+}
+.timer-shell {
+  display:grid;
+  gap:24px;
+}
+.timer-top {
+  display:grid;
+  gap:20px;
+}
+.timer-bar {
+  display:flex;
+  flex-wrap:wrap;
+  align-items:stretch;
+  justify-content:center;
+  gap:18px;
+}
+.timer-bar > * {
+  flex:1 1 260px;
+}
+.chrono-card{
+  display:grid; grid-template-columns:1fr auto; gap:20px;
+  align-items:center; padding:18px 22px; border-radius:999px;
+  background:linear-gradient(140deg,rgba(13,28,61,.8),rgba(61,220,151,.12));
+  border:1px solid rgba(61,220,151,.35);
+}
+.chrono-main{display:grid; justify-items:center; gap:6px}
+.chrono-display{font-variant-numeric:tabular-nums; font-size:3rem; font-weight:700}
+.chrono-state{font-size:.8rem; color:var(--muted); letter-spacing:.08em; text-transform:uppercase}
+.chrono-meta{display:flex; gap:16px}
+.chrono-meta .meta{background:rgba(255,255,255,.06); border:1px solid rgba(255,255,255,.12);
+  padding:10px 14px; border-radius:14px; min-width:120px; text-align:center}
+.chrono-meta .value{font-weight:700; font-size:1.1rem}
+.chrono-meta small{opacity:.8}
+.main-actions {
+  display:flex;
+  flex:2 1 320px;
+  gap:12px;
+  flex-wrap:wrap;
+  justify-content:center;
+  align-items:stretch;
+}
+.main-actions button {
+  flex:1 1 160px;
+  min-height:52px;
+}
+@media (max-width:1279px) {
+  .main-actions {
+    flex-direction:column;
+    align-items:stretch;
+  }
+  .main-actions button {
+    width:100%;
+  }
+}
+@media (max-width:900px) {
+  .timer-bar > * {
+    flex:1 1 100%;
+  }
+}
+.round-pill {
+  background:rgba(9,18,40,.85);
+  border:1px solid rgba(255,255,255,.08);
+  border-radius:999px;
+  padding:12px 20px;
+  display:grid;
+  gap:6px;
+  text-align:center;
+  min-width:220px;
+}
+.round-pill strong {
+  font-size:1.2rem;
+  letter-spacing:.05em;
+}
+#display {
+  font-variant-numeric:tabular-nums;
+  font-size:3rem;
+  line-height:1;
+  font-weight:700;
+}
+.main-actions {
+  display:flex;
+  flex-wrap:wrap;
+  justify-content:center;
+  gap:12px;
+}
+button.primary {
+  background:var(--accent);
+  color:#021221;
+  font-weight:700;
+}
+button.secondary {
+  background:rgba(255,255,255,.08);
+  border:1px solid rgba(255,255,255,.16);
+  color:var(--fg);
+}
+button.danger { background:var(--danger); border-color:transparent; }
+button.warn { background:var(--warn); border-color:transparent; color:#051933; }
+button.ghost { background:transparent; border:1px solid rgba(255,255,255,.18); }
+button {
+  border-radius:var(--radius);
+  border:none;
+  padding:12px 18px;
+  font-weight:600;
+  cursor:pointer;
+  min-height:48px;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:10px;
+  transition:transform .2s ease, background .2s ease;
+}
+button:disabled {
+  cursor:not-allowed;
+  opacity:.5;
+  transform:none !important;
+}
+button:not(:disabled):active { transform:translateY(1px); }
+.icon { font-family:"Fira Code", monospace; font-size:1rem; }
+.progress-bar {
+  width:100%;
+  height:14px;
+  background:rgba(255,255,255,.08);
+  border-radius:999px;
+  overflow:hidden;
+}
+.progress-value {
+  width:0%;
+  height:100%;
+  background:var(--accent);
+  transition:width .2s ease, background .2s ease;
+}
+#state { text-transform:uppercase; letter-spacing:0.12em; font-size:0.75rem; color:var(--muted); text-align:center; }
+#now { font-variant-numeric:tabular-nums; font-size:0.85rem; color:var(--muted); text-align:right; }
+.badge {
+  border-radius:999px;
+  padding:6px 12px;
+  font-size:0.75rem;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+  background:rgba(255,255,255,.12);
+  color:var(--muted);
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+}
+.badge.hc { background:rgba(255,255,255,.08); color:var(--warn); border:1px solid rgba(255,183,3,.4); }
+#progress { margin-top:-12px; }
+.phase-chips {
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+}
+.phase-chip {
+  background:rgba(15,26,52,.8);
+  border:1px solid rgba(255,255,255,.12);
+  color:var(--fg);
+  padding:10px 18px;
+  border-radius:999px;
+  cursor:pointer;
+  min-height:48px;
+  display:flex;
+  align-items:center;
+  gap:8px;
+  transition:transform .2s ease, border-color .2s ease, background .2s ease;
+}
+.phase-chip.active {
+  background:var(--accent);
+  color:#021221;
+  border-color:transparent;
+}
+.phase-chip .dot {
+  width:10px;
+  height:10px;
+  border-radius:999px;
+  background:rgba(255,255,255,.3);
+}
+.phase-chip[data-phase="Activité CHGT de PO"] .dot { background:var(--warn); }
+.phase-chip[data-phase="Début de PO"] .dot { background:#7ad3ff; }
+.phase-chip[data-phase="Fin de PO"] .dot { background:#9b8dff; }
+.phase-chip[data-phase="Vide de ligne"] .dot { background:#ff7ad9; }
+.ops-columns {
+  display:grid;
+  gap:16px;
+}
+@media (min-width:960px) {
+  .ops-columns {
+    grid-template-columns:repeat(auto-fit,minmax(200px,1fr));
+  }
+}
+.operator-card {
+  background:rgba(9,18,40,.7);
+  border:1px solid rgba(255,255,255,.08);
+  border-radius:var(--radius-lg);
+  padding:18px;
+  display:grid;
+  gap:16px;
+  min-height:220px;
+}
+.operator-card.focused {
+  border-color:var(--accent);
+  box-shadow:0 0 0 2px rgba(61,220,151,.35);
+}
+/* Colonne + pastille opérateur */
+.op-col{display:grid;gap:10px;align-content:start}
+.operator-badge{
+  display:inline-flex;align-items:center;justify-content:center;
+  padding:10px 16px;border-radius:999px;
+  background:rgba(61,220,151,.15);border:1px solid rgba(61,220,151,.55);
+  color:var(--fg);font-weight:700;letter-spacing:.02em;min-height:42px;font-size:.95rem;
+  backdrop-filter:blur(8px);
+}
+.operator-badge.focused{box-shadow:0 0 0 3px rgba(61,220,151,.28);background:rgba(61,220,151,.22)}
+.operator-header {
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  gap:8px;
+}
+.operator-header h3 {
+  margin:0;
+  font-size:1rem;
+}
+.operator-header .progress-text { font-size:0.75rem; letter-spacing:0.08em; color:var(--muted); }
+.op-list {
+  display:flex;
+  flex-direction:column;
+  gap:10px;
+}
+.op-item { display:grid; gap:8px; }
+.op-item-head { display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
+.details-chip {
+  padding:8px 14px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,.18);
+  background:rgba(255,255,255,.08);
+  font-size:0.75rem;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+  cursor:pointer;
+  transition:color .2s ease, border-color .2s ease, background .2s ease;
+}
+.details-chip.has-content {
+  border-color:rgba(61,220,151,.55);
+  color:var(--accent);
+  background:rgba(61,220,151,.12);
+}
+.details-chip[aria-expanded="true"] {
+  border-color:var(--accent);
+  background:rgba(61,220,151,.18);
+  color:var(--accent);
+}
+.details-chip.is-empty { opacity:.6; }
+.details-chip:focus-visible,
+.details-chip:hover {
+  border-color:var(--accent);
+  color:var(--accent);
+}
+.op-details {
+  border:1px solid rgba(255,255,255,.1);
+  border-radius:var(--radius);
+  background:rgba(255,255,255,.05);
+  padding:12px 14px;
+  font-size:0.85rem;
+  line-height:1.5;
+  color:var(--fg);
+  display:none;
+  animation:detailsIn .25s ease;
+}
+.op-details.open { display:block; }
+@keyframes detailsIn {
+  from { opacity:0; transform:translateY(-4px); }
+  to { opacity:1; transform:translateY(0); }
+}
+.op-pill {
+  display:flex;
+  align-items:center;
+  gap:10px;
+  padding:12px 14px;
+  border-radius:var(--radius);
+  border:1px solid rgba(255,255,255,.08);
+  background:rgba(23,36,71,.8);
+  cursor:pointer;
+  position:relative;
+  min-height:48px;
+  transition:transform .2s ease, background .2s ease, border-color .2s ease;
+}
+.op-pill .index {
+  width:28px;
+  height:28px;
+  border-radius:999px;
+  background:rgba(255,255,255,.1);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  font-weight:600;
+}
+.op-pill.current {
+  border-color:var(--accent);
+  outline:2px solid rgba(61,220,151,.35);
+  transform:scale(1.08);
+}
+.op-pill.done {
+  background:rgba(61,220,151,.15);
+  border-color:rgba(61,220,151,.6);
+  transform:scale(0.84);
+  color:var(--accent);
+}
+.op-pill.done .index { background:rgba(61,220,151,.45); color:#021221; }
+.op-pill.done .check { display:inline; }
+.check { display:none; font-weight:700; }
+.log-table-wrapper {
+  max-height:420px;
+  overflow:auto;
+  border-radius:var(--radius-lg);
+  border:1px solid rgba(255,255,255,.1);
+}
+table { width:100%; border-collapse:collapse; font-size:0.9rem; }
+th,td {
+  padding:12px 14px;
+  border-bottom:1px solid rgba(255,255,255,.05);
+}
+th {
+  position:sticky;
+  top:0;
+  background:rgba(12,22,46,.95);
+  text-align:left;
+  font-size:0.75rem;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+}
+tbody tr:hover { background:rgba(255,255,255,.04); }
+td.note-cell {
+  min-width:200px;
+}
+td.note-cell[contenteditable="true"] {
+  outline:none;
+}
+tfoot td { font-weight:700; }
+.label-muted { color:var(--muted); font-size:0.8rem; }
+.actions-row {
+  display:flex;
+  flex-wrap:wrap;
+  gap:12px;
+}
+#fullscreen {
+  justify-self:flex-end;
+}
+.chip-row {
+  display:flex;
+  gap:10px;
+  flex-wrap:wrap;
+}
+.chip {
+  padding:10px 16px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,.1);
+  background:rgba(255,255,255,.06);
+  cursor:pointer;
+}
+.chip.active {
+  background:var(--accent);
+  color:#021221;
+  border-color:transparent;
+}
+.toast-container {
+  position:fixed;
+  bottom:24px;
+  right:24px;
+  display:grid;
+  gap:12px;
+  z-index:2000;
+}
+.toast {
+  background:rgba(15,26,52,.92);
+  border:1px solid rgba(61,220,151,.35);
+  border-radius:var(--radius);
+  padding:12px 16px;
+  min-width:220px;
+  box-shadow:var(--shadow);
+  display:flex;
+  align-items:center;
+  gap:12px;
+}
+.toast .icon { color:var(--accent); }
+.tag { padding:4px 10px; border-radius:999px; background:rgba(255,255,255,.1); font-size:0.7rem; letter-spacing:0.08em; }
+/* Parameters */
+.section-group { display:grid; gap:20px; }
+.general-panel { display:grid; gap:20px; }
+.general-settings-bar {
+  display:flex;
+  flex-wrap:wrap;
+  gap:16px;
+  align-items:stretch;
+}
+.param-tile {
+  background:rgba(15,26,52,.78);
+  border:1px solid rgba(255,255,255,.08);
+  border-radius:var(--radius-lg);
+  padding:18px;
+  display:grid;
+  gap:12px;
+  min-width:220px;
+  flex:1 1 240px;
+}
+.param-tile h3 {
+  margin:0;
+  font-size:0.85rem;
+  text-transform:uppercase;
+  letter-spacing:0.08em;
+  color:var(--muted);
+}
+.general-actions {
+  margin-left:auto;
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  align-self:stretch;
+  justify-content:flex-end;
+}
+.events-panel { display:grid; gap:16px; }
+.event-form {
+  display:flex;
+  flex-wrap:wrap;
+  gap:12px;
+  align-items:flex-end;
+}
+.event-form .field { flex:1 1 240px; }
+.event-form button { align-self:flex-end; min-height:48px; }
+.events-list {
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:grid;
+  gap:10px;
+}
+.events-list li {
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:12px;
+  background:rgba(9,18,40,.6);
+  border:1px solid rgba(255,255,255,.08);
+  border-radius:var(--radius);
+  padding:10px 14px;
+}
+.events-list li span { flex:1; }
+.events-list li button {
+  border:1px solid rgba(255,255,255,.12);
+  border-radius:999px;
+  padding:6px 12px;
+  background:rgba(255,255,255,.06);
+  cursor:pointer;
+}
+.events-list li button:hover { border-color:var(--danger); color:var(--danger); }
+.events-list .empty { color:var(--muted); font-style:italic; }
+.phases-panel {
+  display:grid;
+  gap:24px;
+}
+@media (max-width:900px) {
+  .general-actions {
+    width:100%;
+    flex-direction:row;
+    justify-content:flex-end;
+  }
+  .general-actions button {
+    flex:1 1 auto;
+  }
+}
+.switch-row { display:flex; align-items:center; gap:12px; }
+.switch-row input[type="checkbox"] { width:50px; height:26px; border-radius:999px; appearance:none; background:rgba(255,255,255,.08); position:relative; cursor:pointer; }
+.switch-row input[type="checkbox"]::after {
+  content:"";
+  position:absolute;
+  top:3px; left:3px;
+  width:20px; height:20px;
+  border-radius:999px;
+  background:#fff;
+  transition:transform .2s ease;
+}
+.switch-row input[type="checkbox"]:checked { background:var(--accent); }
+.switch-row input[type="checkbox"]:checked::after { transform:translateX(24px); background:#021221; }
+.phase-table-wrapper {
+  border:1px solid rgba(255,255,255,.08);
+  border-radius:var(--radius-lg);
+  overflow:auto;
+  max-height:360px;
+}
+.param-table { width:100%; border-collapse:separate; border-spacing:0; min-width:520px; }
+.param-table thead th {
+  position:sticky;
+  top:0;
+  background:rgba(12,22,46,.95);
+  text-align:left;
+  z-index:1;
+}
+.param-table tbody tr { background:rgba(9,18,40,.6); }
+.param-table td { border-bottom:1px solid rgba(255,255,255,.05); padding:10px 12px; }
+.param-table tbody tr.dragging { opacity:.4; }
+.row-tools { display:flex; gap:8px; }
+.batch-actions { display:flex; flex-wrap:wrap; gap:10px; }
+.phase-toolbar {
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px;
+  align-items:center;
+  padding:12px;
+  border-bottom:1px solid rgba(255,255,255,.05);
+  background:rgba(9,18,40,.55);
+  position:sticky;
+  top:0;
+  z-index:2;
+}
+.phase-toolbar .phase-toolbar-group {
+  display:flex;
+  gap:8px;
+  align-items:center;
+}
+.phase-toolbar .phase-toolbar-group label {
+  font-size:0.85rem;
+  color:var(--muted);
+}
+.phase-toolbar select {
+  min-width:200px;
+  padding:8px 12px;
+  border-radius:999px;
+  border:1px solid rgba(255,255,255,.18);
+  background:rgba(15,26,52,.85);
+}
+.phase-filter-chips {
+  display:flex;
+  flex-wrap:wrap;
+  gap:6px;
+  align-items:center;
+}
+.phase-filter-chip {
+  border:1px solid rgba(255,255,255,.12);
+  border-radius:999px;
+  padding:6px 12px;
+  background:transparent;
+  color:inherit;
+  cursor:pointer;
+  font-size:0.85rem;
+  transition:background .2s ease, border-color .2s ease;
+}
+.phase-filter-chip.active {
+  background:var(--accent);
+  color:#021221;
+  border-color:transparent;
+}
+.phase-toolbar-toggle {
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+  font-size:0.85rem;
+  color:var(--muted);
+}
+.phase-toolbar-toggle input {
+  width:18px;
+  height:18px;
+}
+.param-table tbody tr.is-filtered {
+  display:none;
+}
+.param-table tbody tr.op-group-header-row td {
+  padding-top:16px;
+  padding-bottom:6px;
+}
+.op-group-header {
+  font-size:0.8rem;
+  letter-spacing:0.08em;
+  text-transform:uppercase;
+  opacity:0.8;
+}
+.import-group {
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:10px;
+  padding:12px 18px;
+  border-radius:var(--radius);
+  border:1px solid rgba(255,255,255,.18);
+  background:transparent;
+  font-weight:600;
+  cursor:pointer;
+  min-height:48px;
+  color:inherit;
+  transition:color .2s ease, border-color .2s ease;
+}
+.import-group:hover,
+.import-group:focus-within {
+  border-color:var(--accent);
+  color:var(--accent);
+}
+.import-group input[type="file"] { display:none; }
+textarea { background:rgba(15,26,52,.8); border:1px solid rgba(255,255,255,.12); border-radius:var(--radius); padding:12px; min-height:110px; }
+.param-table textarea {
+  min-height:72px;
+  resize:vertical;
+  width:100%;
+  color:inherit;
+}
+summary { cursor:pointer; }
+/* Analysis */
+.analysis-grid { display:grid; gap:20px; }
+@media (min-width:1280px) {
+  .analysis-grid { grid-template-columns:400px minmax(0,1fr); }
+}
+.kpi-grid { display:grid; gap:12px; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); }
+.kpi-card { background:rgba(9,18,40,.7); border-radius:var(--radius-lg); padding:16px; border:1px solid rgba(255,255,255,.08); display:grid; gap:6px; }
+.kpi-card strong { font-size:1.3rem; font-variant-numeric:tabular-nums; }
+.bar-chart { display:grid; gap:14px; }
+.bar-row { display:grid; gap:6px; }
+.bar-row .label { font-size:0.85rem; color:var(--muted); display:flex; justify-content:space-between; }
+.bar-row .bar {
+  height:12px;
+  border-radius:999px;
+  background:rgba(255,255,255,.08);
+  overflow:hidden;
+}
+.bar-row .fill {
+  height:100%;
+  background:var(--accent);
+  transition:width .3s ease;
+}
+.bar-row .fill.good { background:var(--accent); }
+.bar-row .fill.warn { background:var(--warn); }
+.bar-row .fill.bad { background:var(--danger); }
+.list-card { display:grid; gap:12px; }
+.list-card ol, .list-card ul { margin:0; padding-left:20px; display:grid; gap:8px; }
+.list-card li { font-size:0.9rem; }
+.bad { color:var(--danger); }
+.notice { padding:14px 16px; background:rgba(255,255,255,.08); border-radius:var(--radius); }
+.quick-event-menu {
+  position:absolute;
+  background:rgba(15,26,52,.95);
+  border:1px solid rgba(255,255,255,.12);
+  border-radius:var(--radius);
+  padding:8px;
+  display:grid;
+  gap:6px;
+  min-width:220px;
+  z-index:3000;
+  box-shadow:var(--shadow);
+}
+.quick-event-menu button {
+  background:transparent;
+  border:1px solid rgba(255,255,255,.12);
+  border-radius:var(--radius);
+  padding:8px 10px;
+  color:var(--fg);
+  text-align:left;
+  cursor:pointer;
+}
+.quick-event-menu button:hover,
+.quick-event-menu button:focus-visible {
+  border-color:var(--accent);
+  color:var(--accent);
+}
+.done-group{margin-bottom:6px}
+.done-group summary{
+  list-style:none; cursor:pointer; user-select:none;
+  padding:8px 12px; border-radius:12px; font-size:.85rem;
+  background:rgba(61,220,151,.10); border:1px solid rgba(61,220,151,.35);
+  display:flex; align-items:center; justify-content:space-between; gap:8px;
+}
+.done-group summary::-webkit-details-marker{display:none}
+.done-group .count{opacity:.8; font-variant-numeric:tabular-nums}
+.done-list{display:flex; flex-direction:column; gap:10px; padding-top:8px}
+#openReport{
+  background: var(--accent); color:#021221; font-weight:800;
+  padding:12px 18px; border-radius:999px; box-shadow:0 10px 24px rgba(61,220,151,.25);
+}
+#openReport:hover{ transform: translateY(-1px); }
+.pill-actions{
+  margin-left:auto;
+  display:inline-flex;
+  align-items:center;
+  gap:8px;
+}
+.op-pill .note-btn,
+.pill-actions .pill-action{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  padding:8px 12px;
+  min-width:64px;
+  min-height:40px;
+  border:1px solid rgba(255,255,255,.18);
+  background:rgba(255,255,255,.10);
+  border-radius:999px;
+  font-size:.9rem;
+  line-height:1;
+  cursor:pointer;
+}
+.op-pill .note-btn:hover,
+.op-pill .note-btn:focus-visible,
+.pill-actions .pill-action:hover,
+.pill-actions .pill-action:focus-visible{
+  border-color: var(--accent);
+  box-shadow: var(--focus);
+}
+.op-pill .note-btn.has-note{
+  border-color: var(--accent);
+  color: var(--accent);
+  background: rgba(61,220,151,.10);
+}
+.pill-actions .pill-action--ghost{
+  background:rgba(255,255,255,.06);
+  min-width:auto;
+  padding:8px 14px;
+}
+#splash {
+  position:fixed;
+  inset:0;
+  z-index:9999;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  padding:48px 16px;
+  background:radial-gradient(120% 120% at 50% 15%,rgba(20,34,74,.95) 0%,rgba(6,12,28,.98) 70%,rgba(3,7,18,1) 100%);
+  transition:opacity .6s ease;
+}
+#splash::before{
+  content:"";
+  position:absolute;
+  inset:0;
+  background:radial-gradient(circle at center,rgba(61,220,151,.05) 0%,rgba(15,26,52,0) 55%);
+  pointer-events:none;
+}
+#splash.is-hiding{
+  opacity:0;
+  pointer-events:none;
+}
+.splash-vignette{
+  position:relative;
+  display:grid;
+  gap:18px;
+  justify-items:center;
+  padding:36px clamp(32px,5vw,56px);
+  border-radius:28px;
+  background:linear-gradient(148deg,rgba(15,26,52,.92) 0%,rgba(23,36,71,.88) 100%);
+  border:1px solid rgba(255,255,255,.06);
+  box-shadow:0 30px 80px rgba(7,14,33,.55);
+  overflow:hidden;
+  animation:splashZoomIn 900ms cubic-bezier(.16,1,.3,1) forwards;
+}
+.splash-vignette::before{
+  content:"";
+  position:absolute;
+  inset:-35% -20%;
+  background:radial-gradient(circle at 50% 20%,rgba(255,255,255,.12) 0%,rgba(255,255,255,0) 60%);
+  opacity:.35;
+  pointer-events:none;
+}
+.splash-vignette::after{
+  content:"";
+  position:absolute;
+  inset:0;
+  border-radius:inherit;
+  box-shadow:0 0 0 0 rgba(61,220,151,.28);
+  animation:splashGlow 2200ms ease-in-out infinite;
+  pointer-events:none;
+}
+.splash-logo-wrap{
+  position:relative;
+  display:grid;
+  justify-items:center;
+  width:clamp(220px,22vw,420px);
+}
+.splash-logo{
+  width:100%;
+  height:auto;
+  filter:drop-shadow(0 18px 32px rgba(0,0,0,.45));
+}
+.splash-logo-fallback{
+  font-weight:800;
+  letter-spacing:.16em;
+  font-size:clamp(2.6rem,8vw,4.5rem);
+}
+.splash-caption{
+  font-size:.9rem;
+  opacity:.7;
+  letter-spacing:.08em;
+  text-transform:uppercase;
+}
+.logo-container{
+  display:grid;
+  place-items:center;
+}
+.logo-image{ display:block; }
+.logo-container .logo-fallback-text{
+  display:none;
+}
+.logo-container.logo-missing .logo-image{ display:none; }
+.logo-container.logo-missing .logo-fallback-text{ display:block; }
+.brand-mark{
+  width:44px;
+  height:44px;
+  display:grid;
+  place-items:center;
+}
+.brand-logo{ width:100%; height:100%; object-fit:contain; filter:drop-shadow(0 6px 16px rgba(0,0,0,.35)); }
+.brand-logo-fallback{ font-weight:800; letter-spacing:.12em; font-size:.95rem; }
+@keyframes splashZoomIn{
+  0%{ transform:scale(.84); opacity:0; }
+  100%{ transform:scale(1); opacity:1; }
+}
+@keyframes splashGlow{
+  0%,100%{ box-shadow:0 0 0 0 rgba(61,220,151,.18); }
+  50%{ box-shadow:0 0 25px 10px rgba(61,220,151,.22); }
+}
+@media print {
+  body { background:#fff; color:#000; }
+  .app { display:block; }
+  header, .nav-tabs, #fullscreen, .toast-container { display:none !important; }
+  main { padding:0; }
+  .panel { background:#fff !important; border:1px solid #ccc; box-shadow:none; }
+  .page { display:block !IMPORTANT; }
+  .ops-columns, .kpi-grid, .bar-chart { page-break-inside:avoid; }
+}
+/* PATCH ANALYSE PREMIUM */
+.analyse-kpi-enhanced { display:grid; gap:12px; grid-template-columns:repeat(auto-fit,minmax(180px,1fr)); }
+.kpi-card--color-good { border-left:4px solid var(--accent); }
+.kpi-card--color-warn { border-left:4px solid var(--warn); }
+.kpi-card--color-bad { border-left:4px solid var(--danger); }
+.analyse-kpi-enhanced .kpi-card small { font-size:.78rem; color:var(--muted); }
+.bar-row--enhanced { position:relative; }
+.bar-row--enhanced:hover .bar-tooltip { display:block; }
+.bar-tooltip { display:none; position:absolute; top:-60px; left:50%; transform:translateX(-50%); background:rgba(15,26,52,.95); border:1px solid rgba(255,255,255,.18); border-radius:var(--radius); padding:8px 12px; font-size:.85rem; z-index:100; white-space:nowrap; }
+.analyse-critical-ops table { width:100%; border-collapse:collapse; font-size:.9rem; }
+.analyse-critical-ops th,
+.analyse-critical-ops td { padding:10px 12px; border-bottom:1px solid rgba(255,255,255,.08); }
+.badge--fire { background:rgba(239,71,111,.2); color:var(--danger); border:1px solid var(--danger); }
+.badge--warn { background:rgba(255,183,3,.2); color:var(--warn); border:1px solid var(--warn); }
+.analyse-insights { background:rgba(255,183,3,.1); border:1px solid rgba(255,183,3,.35); border-radius:var(--radius-lg); padding:18px; }
+.insights-text { font-size:.95rem; line-height:1.6; }
+.insights-text li { margin-bottom:6px; }
+.analyse-perturbateurs-enhanced ul { list-style:none; margin:0; padding:0; display:grid; gap:8px; }
+.analyse-perturbateurs-enhanced li { display:flex; justify-content:space-between; align-items:center; background:rgba(15,26,52,.45); padding:10px 12px; border-radius:var(--radius); border:1px solid rgba(255,255,255,.08); }
+.analyse-comparison { margin-top:24px; display:grid; gap:16px; }
+.comparison-controls { display:flex; flex-wrap:wrap; gap:12px; }
+.comparison-controls label { display:grid; gap:4px; font-size:.85rem; color:var(--muted); }
+.comparison-controls select { min-width:140px; border-radius:var(--radius-sm); border:1px solid rgba(255,255,255,.16); background:rgba(15,26,52,.6); padding:6px 10px; color:inherit; }
+.comparison-chart { min-height:160px; border:1px solid rgba(255,255,255,.12); border-radius:var(--radius-lg); display:flex; align-items:center; justify-content:center; padding:12px; background:rgba(15,26,52,.4); }
+.comparison-chart svg { width:100%; height:100%; }
+.comparison-legend { display:flex; gap:16px; justify-content:center; flex-wrap:wrap; font-size:.85rem; }
+.comparison-legend span { display:inline-flex; align-items:center; gap:6px; }
+.comparison-legend span::before { content:''; width:12px; height:12px; border-radius:999px; background:var(--accent); }
+.comparison-legend span[data-color="warn"]::before { background:var(--warn); }
+/* PATCH SMED — styles opérateur */
+.operator-header .meta-line{ display:flex; align-items:center; gap:10px; font-variant-numeric: tabular-nums; }
+.operator-header .meta-line .time{ font-weight:700; }
+.operator-header .meter{
+  height:4px; border-radius:999px; background:rgba(255,255,255,.08); overflow:hidden; margin-top:6px;
+}
+.operator-header .meter .fill{ height:100%; background:var(--accent); width:0%; transition:width .25s ease; }
+.operator-card .op-pill.current{ box-shadow:0 0 0 2px rgba(61,220,151,.45), 0 0 16px rgba(61,220,151,.25) inset; }
+.operator-card .op-pill.current::before{ content:"▶"; margin-right:8px; opacity:.9; }
+.badge.time-ok{ color:var(--accent); }
+.badge.time-warn{ color:var(--warn); }
+.badge.time-bad{ color:var(--danger); }
+.ops-toolbar{ display:flex; gap:10px; align-items:center; flex-wrap:wrap; }
+/* PATCH op-event */
+.op-evt-btn{
+  display:inline-flex; align-items:center; gap:8px;
+  padding:8px 12px; border-radius:999px;
+  background:rgba(61,220,151,.12);
+  border:1px solid rgba(61,220,151,.35);
+  color:var(--fg); font-size:.85rem; cursor:pointer;
+}
+.op-evt-btn:hover{ box-shadow:0 0 0 2px rgba(61,220,151,.25); }
+</style>
+</head>
+<body>
+<div id="splash" role="dialog" aria-label="Écran de lancement">
+  <div class="splash-vignette">
+    <div class="splash-logo-wrap logo-container">
+      <img src="smed-logo.png" alt="Logo SMED" class="splash-logo logo-image">
+      <span class="splash-logo-fallback logo-fallback-text" aria-hidden="true">SMED</span>
+    </div>
+    <div class="splash-caption">Chargement du tableau de bord…</div>
+  </div>
+</div>
+<div class="app">
+  <header>
+    <div class="top-nav">
+      <div class="brand">
+        <div class="brand-mark logo-container">
+          <img src="smed-logo.png" alt="SMED" class="brand-logo logo-image">
+          <span class="brand-logo-fallback logo-fallback-text" aria-hidden="true">SMED</span>
+        </div>
+        <span class="brand-sep" aria-hidden="true"></span>
+        <span class="brand-line" id="brandLine">L29</span>
+      </div>
+      <div class="nav-tabs" role="tablist">
+        <button type="button" data-target="timerPage" class="active" aria-controls="timerPage" aria-selected="true">SMED</button>
+        <button type="button" data-target="analysisPage" aria-controls="analysisPage" aria-selected="false">Analyse</button>
+        <button type="button" data-target="paramsPage" aria-controls="paramsPage" aria-selected="false">Paramètres</button>
+      </div>
+      <div class="header-actions">
+        <button id="toggleJournal" class="ghost" type="button" aria-pressed="false" title="Afficher/Masquer Journal"><span class="icon">🗂</span>Masquer le journal</button>
+        <button id="fullscreen" class="ghost" type="button" aria-label="Plein écran"><span class="icon">⤢</span>Plein écran</button>
+      </div>
+    </div>
+  </header>
+  <main>
+    <section id="timerPage" class="page active" aria-labelledby="Timer">
+      <div class="timer-grid">
+        <div class="panel">
+          <div class="timer-shell">
+            <div class="id-row">
+              <div class="field"><label>Ligne<input id="line" type="text" placeholder="Code ligne"></label></div>
+              <div class="field"><label>PO<input id="po" type="text" placeholder="Ordre de production"></label></div>
+              <div class="field"><label>Mode<select id="mode"><option value="up">Chrono croissant</option><option value="down">Chrono décroissant</option></select></label></div>
+            </div>
+            <div class="timer-top">
+              <div class="timer-bar">
+                <div class="chrono-card">
+                  <div class="chrono-main">
+                    <div class="chrono-title label-muted">Chronomètre</div>
+                    <div id="display" class="chrono-display">00:00:00</div>
+                    <div id="state" class="chrono-state">Prêt</div>
+                  </div>
+                  <div class="chrono-meta">
+                    <div class="meta">
+                      <div class="label-muted">Cible</div>
+                      <div class="value"><span id="targetMin">0</span> <small>min</small></div>
+                    </div>
+                    <div class="meta">
+                      <div class="label-muted">Alerte</div>
+                      <div class="value"><span id="warnMin">0</span> <small>min</small></div>
+                    </div>
+                  </div>
+                </div>
+                <div class="main-actions">
+                  <button id="start" class="primary" type="button"><span class="icon">▶</span>Démarrer</button>
+                  <!-- PATCH op-event: libellé bouton mis à jour -->
+                  <button id="lap" class="secondary" type="button"><span class="icon">✦</span>Évènement Hors changement</button>
+                  <button id="end" class="warn" type="button"><span class="icon">■</span>Fin du changement</button>
+                  <button id="reset" class="danger" type="button"><span class="icon">↺</span>Reset session</button>
+                </div>
+              </div>
+              <div class="progress-bar" id="progress" aria-hidden="true"><div class="progress-value"></div></div>
+              <div class="chip-row" id="phaseChips" role="tablist"></div>
+              <div class="label-muted" id="now"></div>
+            </div>
+            <!-- PATCH SMED — toolbar opérateurs -->
+            <div id="opsToolbar" class="ops-toolbar" aria-label="Outils affichage opérations">
+              <!-- PATCH rm-toggle: suppression du toggle "Montrer seulement la courante" -->
+              <button id="undoLast" type="button" class="ghost">↺ Annuler dernière</button>
+              <span id="hcMini" class="badge" style="display:none;"></span>
+            </div>
+            <div class="ops-columns" id="opsPhaseChips"></div>
+          </div>
+        </div>
+        <aside id="journalAside" class="panel compact">
+          <div class="panel-title">
+            <h2>Journal</h2>
+            <div class="badge" id="logCount">0 entrées</div>
+          </div>
+          <div class="log-table-wrapper" role="region" aria-live="polite">
+            <table>
+              <thead>
+                <tr>
+                  <th>#</th>
+                  <th>Horodatage</th>
+                  <th>Durée</th>
+                  <th>HC</th>
+                  <th>Phase</th>
+                  <th>Opérateur</th>
+                  <th>Libellé</th>
+                  <th>Note</th>
+                </tr>
+              </thead>
+              <tbody id="logTable"></tbody>
+              <tfoot>
+                <tr>
+                  <td colspan="2">Total chrono</td>
+                  <td id="totalCell">00:00:00</td>
+                  <td colspan="5"></td>
+                </tr>
+              </tfoot>
+            </table>
+          </div>
+          <div class="actions-row" style="margin-top:16px;">
+            <button id="exportCsv" class="ghost" type="button">Exporter CSV</button>
+            <button id="exportHtml" class="ghost" type="button">Exporter rapport</button>
+          </div>
+        </aside>
+      </div>
+    </section>
+    <section id="paramsPage" class="page" aria-labelledby="Paramètres">
+      <div class="panel general-panel">
+        <div class="panel-title"><h2>Paramètres généraux</h2><div class="badge">Auto-save actif</div></div>
+        <div class="general-settings-bar">
+          <div class="param-tile">
+            <h3>Opérateurs</h3>
+            <div class="field"><label>Opérateur 1<input type="text" id="op1"></label></div>
+            <div class="field"><label>Opérateur 2<input type="text" id="op2"></label></div>
+            <div class="field"><label>Opérateur 3<input type="text" id="op3"></label></div>
+            <div class="field"><label>Opérateur 4<input type="text" id="op4"></label></div>
+          </div>
+          <div class="param-tile">
+            <h3>Assignations</h3>
+            <div class="field"><label>Opérateur par défaut<select id="defaultOperator"></select></label></div>
+            <div class="switch-row"><input id="multiView" type="checkbox"><label for="multiView">Vue multi-opérateurs</label></div>
+          </div>
+          <div class="param-tile">
+            <h3>Alerte</h3>
+            <div class="field"><label>Alerte (min)<input type="number" step="0.5" id="alertInput"></label></div>
+            <button id="suggestAlert" type="button" class="ghost">Suggérer 85 %</button>
+          </div>
+          <div class="general-actions">
+            <button id="saveParams" class="primary" type="button">Sauvegarder</button>
+            <button id="resetParams" class="danger" type="button">Réinitialiser</button>
+          </div>
+        </div>
+      </div>
+      <div class="panel compact events-panel">
+        <div class="panel-title"><h2>Évènements prédéfinis</h2><span class="label-muted">Utilisés par l'événement rapide</span></div>
+        <form id="eventForm" class="event-form">
+          <div class="field">
+            <label>Nouvel événement<input type="text" id="eventInput" placeholder="Libellé d'événement"></label>
+          </div>
+          <button type="submit" class="ghost">Ajouter</button>
+        </form>
+        <ul id="eventsList" class="events-list"></ul>
+      </div>
+      <div class="panel compact phases-panel">
+        <div class="panel-title"><h2>Phases et opérations</h2><span class="label-muted">Glisser-déposer pour réordonner</span></div>
+        <div id="phaseTables"></div>
+      </div>
+    </section>
+    <section id="analysisPage" class="page" aria-labelledby="Analyse">
+      <div class="panel">
+        <div class="panel-title"><h2>Analyse</h2><div class="chip" id="openReport">Rapport</div><button id="exportReportAdvanced" class="ghost" type="button">Export 1-page</button><button id="refreshAnalysis" class="ghost" type="button">Rafraîchir</button></div>
+        <div class="analysis-grid">
+          <div class="panel compact">
+            <div class="analyse-kpi-enhanced" id="kpiGrid"></div>
+            <div class="list-card">
+              <h3>Top 3 pertes</h3>
+              <ol id="topContrib"></ol>
+            </div>
+            <div class="analyse-critical-ops" id="topOps">
+              <h3>Opérations critiques</h3>
+              <table aria-label="Opérations critiques">
+                <thead><tr><th>Opération</th><th>Phase</th><th>Écart</th><th>Note</th></tr></thead>
+                <tbody id="criticalOpsBody"></tbody>
+              </table>
+            </div>
+            <div class="analyse-perturbateurs-enhanced">
+              <h3>Perturbateurs récurrents</h3>
+              <ul id="perturbateurs"></ul>
+            </div>
+            <div class="analyse-insights">
+              <h3>Insights Kaizen</h3>
+              <ul id="insightsList" class="insights-text"></ul>
+            </div>
+          </div>
+          <div class="panel compact">
+            <div class="panel-title"><h3>Phases – cible vs réel</h3><span id="phaseDistributionTarget" class="label-muted"></span></div>
+            <div class="bar-chart" id="phaseDistribution"></div>
+            <div class="panel-title"><h3>Répartition par opérateurs</h3><span id="operatorDistributionTarget" class="label-muted"></span></div>
+            <div class="bar-chart" id="operatorDistribution"></div>
+            <div class="analyse-comparison">
+              <div class="comparison-controls">
+                <label>Session A<select id="comparisonSessionA" aria-label="Comparer la session A"></select></label>
+                <label>Session B<select id="comparisonSessionB" aria-label="Comparer la session B"></select></label>
+              </div>
+              <div class="comparison-chart" id="comparisonChart" role="img" aria-label="Comparaison historique des phases"></div>
+            </div>
+            <div class="panel-title"><h3>Prépa (HC)</h3><span class="label-muted">Checklist & notes</span></div>
+            <div class="notice" id="prepaSummary"></div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+</div>
+<div class="toast-container" id="toastContainer" aria-live="polite"></div>
+<script>
+(() => {
+  const STORAGE_KEY = 'smed_timer_v3';
+  const SCHEMA_VERSION = 5;
+  const phasesList = ['Activité CHGT de PO','Début de PO','Fin de PO','Vide de ligne'];
+  const timedPhases = ['Début de PO','Fin de PO','Vide de ligne'];
+  function newId(){ return 'op_' + Math.random().toString(36).slice(2,10) + Date.now().toString(36); }
+
+  function setupLogoContainer(container) {
+    if (!container) return;
+    const img = container.querySelector('.logo-image');
+    const fallback = container.querySelector('.logo-fallback-text');
+    if (!img || !fallback) return;
+
+    const showFallback = () => {
+      container.classList.add('logo-missing');
+    };
+
+    const hideFallback = () => {
+      container.classList.remove('logo-missing');
+    };
+
+    if (img.complete) {
+      if (img.naturalWidth === 0) {
+        showFallback();
+      } else {
+        hideFallback();
+      }
+    }
+
+    img.addEventListener('error', showFallback);
+    img.addEventListener('load', () => {
+      if (img.naturalWidth === 0) {
+        showFallback();
+      } else {
+        hideFallback();
+      }
+    });
+  }
+  const DEFAULT_STATE = () => ({
+    schema_version: SCHEMA_VERSION,
+    site: '',
+    line: 'L29',
+    po: '',
+    mode: 'up',
+    operators: ['Opérateur A','', '', ''],
+    defaultOperatorIndex: 0,
+    multiView: true,
+    // PATCH SMED — affichage courant only
+    _onlyCurrent: false,
+    events: [],
+    phases: {
+      'Activité CHGT de PO': [
+        { id: newId(), name: 'Checklist sécurité', targetMin: 3, operatorIndex: 0, enabled: true, details: '' }
+      ],
+      'Début de PO': [
+        { id: newId(), name: 'Arrêt ligne', targetMin: 4, operatorIndex: 0, enabled: true, details: '' },
+        { id: newId(), name: 'Changement outillage', targetMin: 6, operatorIndex: 0, enabled: true, details: '' }
+      ],
+      'Fin de PO': [
+        { id: newId(), name: 'Redémarrage', targetMin: 5, operatorIndex: 0, enabled: true, details: '' }
+      ],
+      'Vide de ligne': [
+        { id: newId(), name: 'Nettoyage final', targetMin: 4, operatorIndex: 0, enabled: true, details: '' }
+      ]
+    },
+    alertMin: 12,
+    elapsedMs: 0,
+    prepaElapsedMs: 0,
+    activePhase: 'Activité CHGT de PO',
+    marks: [],
+    sessionStart: Date.now(),
+    runningSince: null,
+    sessionElapsedMs: 0,
+    completedOpsByOp: {},
+    multiViewOverride: null
+  });
+
+  const els = {
+    pages: document.querySelectorAll('.page'),
+    navButtons: document.querySelectorAll('.nav-tabs button'),
+    display: document.getElementById('display'),
+    start: document.getElementById('start'),
+    lap: document.getElementById('lap'),
+    end: document.getElementById('end'),
+    reset: document.getElementById('reset'),
+    state: document.getElementById('state'),
+    progress: document.getElementById('progress').querySelector('.progress-value'),
+    targetMin: document.getElementById('targetMin'),
+    warnMin: document.getElementById('warnMin'),
+    mode: document.getElementById('mode'),
+    line: document.getElementById('line'),
+    po: document.getElementById('po'),
+    now: document.getElementById('now'),
+    logTable: document.getElementById('logTable'),
+    totalCell: document.getElementById('totalCell'),
+    exportCsv: document.getElementById('exportCsv'),
+    exportHtml: document.getElementById('exportHtml'),
+    fullscreen: document.getElementById('fullscreen'),
+    toggleJournal: document.getElementById('toggleJournal'),
+    brandLine: document.getElementById('brandLine'),
+    phaseChips: document.getElementById('phaseChips'),
+    opsPhaseChips: document.getElementById('opsPhaseChips'),
+    saveParams: document.getElementById('saveParams'),
+    resetParams: document.getElementById('resetParams'),
+    refreshAnalysis: document.getElementById('refreshAnalysis'),
+    logCount: document.getElementById('logCount'),
+    toastContainer: document.getElementById('toastContainer'),
+    alertInput: document.getElementById('alertInput'),
+    suggestAlert: document.getElementById('suggestAlert'),
+    defaultOperator: document.getElementById('defaultOperator'),
+    opInputs: [document.getElementById('op1'), document.getElementById('op2'), document.getElementById('op3'), document.getElementById('op4')],
+    multiView: document.getElementById('multiView'),
+    phaseTables: document.getElementById('phaseTables'),
+    kpiGrid: document.getElementById('kpiGrid'),
+    topContrib: document.getElementById('topContrib'),
+    topOps: document.getElementById('topOps'),
+    perturbateurs: document.getElementById('perturbateurs'),
+    criticalOpsBody: document.getElementById('criticalOpsBody'),
+    insightsList: document.getElementById('insightsList'),
+    comparisonSessionA: document.getElementById('comparisonSessionA'),
+    comparisonSessionB: document.getElementById('comparisonSessionB'),
+    comparisonChart: document.getElementById('comparisonChart'),
+    phaseDistribution: document.getElementById('phaseDistribution'),
+    operatorDistribution: document.getElementById('operatorDistribution'),
+    phaseDistributionTarget: document.getElementById('phaseDistributionTarget'),
+    operatorDistributionTarget: document.getElementById('operatorDistributionTarget'),
+    prepaSummary: document.getElementById('prepaSummary'),
+    exportReportAdvanced: document.getElementById('exportReportAdvanced'),
+    progressContainer: document.getElementById('progress'),
+    eventForm: document.getElementById('eventForm'),
+    eventInput: document.getElementById('eventInput'),
+    eventsList: document.getElementById('eventsList'),
+    splash: document.getElementById('splash')
+  };
+
+  let state = migrate(loadState());
+  const runtime = {
+    activePage: 'timerPage',
+    animationFrame: null,
+    lastTick: performance.now(),
+    focusedOperator: state.defaultOperatorIndex || 0,
+    journalHidden: false,
+    analysisTimeout: null,
+    shouldScrollToCurrent: false,
+    quickEventMenu: null,
+    comparisonA: 'current',
+    comparisonB: 'target'
+  };
+  const phaseUiState = new Map();
+  const phaseSections = new Map();
+
+  function loadState() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return DEFAULT_STATE();
+      return JSON.parse(raw);
+    } catch (err) {
+      console.error('Erreur de chargement, réinitialisation', err);
+      return DEFAULT_STATE();
+    }
+  }
+
+  function migrate(data) {
+    const base = DEFAULT_STATE();
+    const defaultLine = base.line;
+    const merged = Object.assign(base, data || {});
+    merged.schema_version = SCHEMA_VERSION;
+    if (typeof merged.line !== 'string' || !merged.line.trim()) {
+      merged.line = defaultLine;
+    }
+    merged.phases = merged.phases || DEFAULT_STATE().phases;
+    merged.operators = Array.isArray(merged.operators) ? merged.operators : ['', '', '', ''];
+    while (merged.operators.length < 4) merged.operators.push('');
+    merged.defaultOperatorIndex = typeof merged.defaultOperatorIndex === 'number' ? merged.defaultOperatorIndex : 0;
+    if (merged.defaultOperatorIndex < 0 || merged.defaultOperatorIndex >= merged.operators.length) {
+      merged.defaultOperatorIndex = 0;
+    }
+    merged.alertMin = Number.isFinite(merged.alertMin) ? merged.alertMin : 0;
+    merged.marks = Array.isArray(merged.marks) ? merged.marks : [];
+    Object.keys(merged.phases).forEach(ph => {
+      merged.phases[ph] = (merged.phases[ph] || []).map(op => {
+        const hasEnabled = op && Object.prototype.hasOwnProperty.call(op, 'enabled');
+        const enabled = hasEnabled ? !(op.enabled === false || op.enabled === 0 || op.enabled === '0') : true;
+        return {
+          ...op,
+          id: op.id || newId(),
+          enabled,
+          details: op && typeof op.details === 'string' ? op.details : ''
+        };
+      });
+    });
+    merged.completedOpsByOp = merged.completedOpsByOp || {};
+    merged.events = Array.isArray(merged.events)
+      ? merged.events.map(label => typeof label === 'string' ? label.trim() : '').filter(label => label)
+      : [];
+    // PATCH SMED — affichage courant only
+    merged._onlyCurrent = !!merged._onlyCurrent;
+    Object.keys(merged.completedOpsByOp).forEach(op => {
+      const phases = typeof merged.completedOpsByOp[op] === 'object' && merged.completedOpsByOp[op] ? merged.completedOpsByOp[op] : {};
+      Object.keys(phases).forEach(ph => {
+        const raw = phases[ph];
+        const asSet = raw instanceof Set ? raw : new Set(Array.isArray(raw) ? raw : Object.values(raw || {}));
+        const ops = merged.phases[ph] || [];
+        const ids = new Set(ops.map(o => o.id));
+        const byName = new Map();
+        ops.forEach(o => {
+          const list = byName.get(o.name) || [];
+          list.push(o.id);
+          byName.set(o.name, list);
+        });
+        const known = new Set();
+        asSet.forEach(val => {
+          if (ids.has(val)) {
+            known.add(val);
+            return;
+          }
+          const list = byName.get(val);
+          if (list && list.length) {
+            known.add(list.shift());
+          }
+        });
+        phases[ph] = known;
+      });
+      merged.completedOpsByOp[op] = phases;
+    });
+    merged.marks = merged.marks.map(m => ({
+      t: m.t ?? 0,
+      phase: m.phase || merged.activePhase || 'Activité CHGT de PO',
+      operator: m.operator || undefined,
+      label: m.label || '',
+      kind: m.kind || 'event',
+      note: m.note || '',
+      hc: !!m.hc,
+      durationMs: m.durationMs || 0,
+      opId: m.opId || null
+    }));
+    if (!Number.isFinite(merged.elapsedMs)) merged.elapsedMs = 0;
+    if (!Number.isFinite(merged.prepaElapsedMs)) merged.prepaElapsedMs = 0;
+    if (!Number.isFinite(merged.sessionElapsedMs)) merged.sessionElapsedMs = 0;
+    if (!merged.sessionStart) merged.sessionStart = Date.now();
+    if (!merged.activePhase || !phasesList.includes(merged.activePhase)) merged.activePhase = 'Activité CHGT de PO';
+    merged.multiView = merged.multiView ?? true;
+    return merged;
+  }
+
+  function serializeState() {
+    const copy = JSON.parse(JSON.stringify(state));
+    copy.completedOpsByOp = {};
+    Object.keys(state.completedOpsByOp).forEach(op => {
+      copy.completedOpsByOp[op] = {};
+      Object.keys(state.completedOpsByOp[op]).forEach(ph => {
+        copy.completedOpsByOp[op][ph] = Array.from(state.completedOpsByOp[op][ph]);
+      });
+    });
+    return copy;
+  }
+
+  function saveState(showToastFlag = false) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(serializeState()));
+      if (showToastFlag) showToast('Paramètres enregistrés ✓');
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  function resetState() {
+    state = DEFAULT_STATE();
+    saveState();
+    refreshAll();
+    showToast('Réinitialisation effectuée');
+  }
+
+  function showToast(message, variant = 'success') {
+    const toast = document.createElement('div');
+    toast.className = 'toast';
+    toast.innerHTML = `<span class="icon">${variant === 'success' ? '✔' : variant === 'error' ? '⚠' : 'ℹ'}</span><span>${message}</span>`;
+    els.toastContainer.appendChild(toast);
+    setTimeout(() => {
+      toast.style.opacity = '0';
+      toast.style.transform = 'translateY(10px)';
+    }, 20);
+    setTimeout(() => toast.remove(), 4200);
+  }
+
+  function formatDuration(ms, showMillis = false) {
+    const total = Math.max(0, Math.floor(ms / 1000));
+    const h = String(Math.floor(total / 3600)).padStart(2,'0');
+    const m = String(Math.floor((total % 3600) / 60)).padStart(2,'0');
+    const s = String(total % 60).padStart(2,'0');
+    if (!showMillis) return `${h}:${m}:${s}`;
+    const cent = String(Math.floor((ms % 1000)/10)).padStart(2,'0');
+    return `${h}:${m}:${s}.${cent}`;
+  }
+
+  function formatMinutesValue(ms, digits = 1) {
+    if (!Number.isFinite(ms)) return '—';
+    return `${(ms / 60000).toFixed(digits)} min`;
+  }
+
+  function escapeHtml(value) {
+    const entities = new Map([
+      ['&', '&amp;'],
+      ['<', '&lt;'],
+      ['>', '&gt;'],
+      ['"', '&quot;'],
+      ['\'', '&#39;']
+    ]);
+    return String(value).replace(/[&<>"']/g, ch => entities.get(ch));
+  }
+
+  function formatDetailsHtml(text) {
+    if (!text || !text.trim()) {
+      return '<span class="label-muted">Aucun détail renseigné</span>';
+    }
+    return escapeHtml(text).replace(/\r?\n/g, '<br>');
+  }
+
+  function sanitizeCsvText(text) {
+    return String(text || '').replace(/\r?\n/g, ' / ').replace(/;/g, ',').trim();
+  }
+
+  function targetMinutesForPhase(phase) {
+    return (state.phases[phase] || [])
+      .filter(op => op.enabled !== false)
+      .reduce((sum, op) => sum + Number(op.targetMin || 0), 0);
+  }
+  function totalTargetMinutes() {
+    return timedPhases.reduce((sum, phase) => sum + targetMinutesForPhase(phase), 0);
+  }
+
+  function updateTargets() {
+    const target = totalTargetMinutes();
+    els.targetMin.textContent = target.toFixed(1);
+    els.warnMin.textContent = state.alertMin ? Number(state.alertMin).toFixed(1) : (target * 0.85).toFixed(1);
+  }
+
+  function ensureCompletedStructures() {
+    for (let idx = 0; idx < state.operators.length; idx++) {
+      const name = getCurrentOperatorName(idx);
+      if (!state.completedOpsByOp[name]) state.completedOpsByOp[name] = {};
+      phasesList.forEach(ph => {
+        if (!(state.completedOpsByOp[name][ph] instanceof Set)) {
+          state.completedOpsByOp[name][ph] = new Set(state.completedOpsByOp[name][ph] || []);
+        }
+      });
+    }
+  }
+
+  function getCurrentOperatorName(index) {
+    return state.operators[index] || `Opérateur ${index+1}`;
+  }
+
+  function getPhaseStateConfig(phase) {
+    if (!phaseUiState.has(phase)) {
+      phaseUiState.set(phase, {
+        sortMode: 'none',
+        filterOperator: null,
+        allowCrossAssign: false
+      });
+    }
+    return phaseUiState.get(phase);
+  }
+
+  function normalizeOperatorIndex(value) {
+    if (!Number.isFinite(value)) return Math.max(0, Math.min(state.operators.length - 1, state.defaultOperatorIndex || 0));
+    const normalized = Math.floor(value);
+    if (normalized < 0) return 0;
+    if (normalized >= state.operators.length) return Math.max(0, state.operators.length - 1);
+    return normalized;
+  }
+
+  function formatOperatorName(index) {
+    const normalized = normalizeOperatorIndex(index);
+    return state.operators[normalized] || `Opérateur n°${normalized + 1}`;
+  }
+
+  function stableSortByOperatorIndex(ops, asc = true) {
+    const mapped = ops.map((op, idx) => ({ op, idx }));
+    mapped.sort((a, b) => {
+      const aIdx = normalizeOperatorIndex(a.op.operatorIndex);
+      const bIdx = normalizeOperatorIndex(b.op.operatorIndex);
+      if (aIdx === bIdx) return a.idx - b.idx;
+      return asc ? aIdx - bIdx : bIdx - aIdx;
+    });
+    return mapped.map(item => item.op);
+  }
+
+  function groupByOperatorIndex(ops) {
+    const groups = new Map();
+    ops.forEach(op => {
+      const idx = normalizeOperatorIndex(op.operatorIndex);
+      if (!groups.has(idx)) groups.set(idx, []);
+      groups.get(idx).push(op);
+    });
+    return groups;
+  }
+
+  function applyPhaseFilterForOperator(ops, operatorIndex = null) {
+    if (operatorIndex == null) return ops.slice();
+    const normalized = normalizeOperatorIndex(operatorIndex);
+    return ops.filter(op => normalizeOperatorIndex(op.operatorIndex) === normalized);
+  }
+
+  // PATCH SMED — stats opérateur/phase
+  function computeOpPhaseStats(operatorIndex, phase){
+    const operatorName = getCurrentOperatorName(operatorIndex);
+    const ops = (state.phases[phase] || []).filter(o => o.enabled !== false)
+      .filter(o => (typeof o.operatorIndex === 'number' ? o.operatorIndex : state.defaultOperatorIndex) === operatorIndex);
+
+    const total = ops.length;
+    // Cible = somme des targetMin de ses ops incluses
+    const targetMs = ops.reduce((s,o) => s + (Number(o.targetMin||0)*60000), 0);
+
+    // Réalisées (Set déjà maintenu par phase)
+    ensureCompletedStructures();
+    const doneSet = (state.completedOpsByOp[operatorName] && state.completedOpsByOp[operatorName][phase]) || new Set();
+    const done = ops.reduce((c,o)=> c + (doneSet.has(o.id||o.name) ? 1 : 0), 0);
+
+    // Temps réel attribué à cet opérateur sur la phase (hors HC)
+    let realMs = 0;
+    let prev = 0, contextPhase = state.marks.length ? state.marks[0].phase : state.activePhase;
+    state.marks.forEach(m=>{
+      const dur = m.durationMs || Math.max(0, m.t - prev);
+      const isPhaseChange = m.kind==='event' && m.label?.toLowerCase().includes('changement de phase');
+      const effectivePhase = isPhaseChange ? contextPhase : m.phase;
+      if (effectivePhase === phase && phase !== 'Activité CHGT de PO' && m.operator === operatorName){
+        if (m.kind === 'op' || m.kind === 'event') realMs += dur;
+      }
+      prev = m.t;
+      contextPhase = m.phase;
+    });
+
+    const percent = total ? Math.round((done/total)*100) : 0;
+    const ratio = targetMs ? (realMs/targetMs) : 0;
+
+    return {done,total,realMs,targetMs,percent,ratio};
+  }
+
+  function renderPhaseChips() {
+    els.phaseChips.innerHTML = '';
+    phasesList.forEach(phase => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'phase-chip' + (state.activePhase === phase ? ' active' : '');
+      btn.dataset.phase = phase;
+      btn.innerHTML = `<span class="dot"></span><span>${phase}${phase === 'Activité CHGT de PO' ? ' (HC)' : ''}</span>`;
+      btn.addEventListener('click', () => {
+        changePhase(phase);
+      });
+      els.phaseChips.appendChild(btn);
+    });
+    // PATCH SMED — mini compteur HC
+    const hcBadge = document.getElementById('hcMini');
+    if (hcBadge){
+      if (state.activePhase === 'Activité CHGT de PO'){
+        const ops = (state.phases['Activité CHGT de PO'] || []).filter(o=>o.enabled !== false);
+        const total = ops.length || 0;
+        const done = state.marks.filter(m => m.phase === 'Activité CHGT de PO' && m.kind === 'op').length;
+        hcBadge.textContent = `HC : ${done}/${total} · ${formatDuration(state.prepaElapsedMs)}`;
+        hcBadge.style.display = 'inline-block';
+      }else{
+        hcBadge.style.display = 'none';
+      }
+    }
+  }
+
+  function renderOperatorColumns() {
+    ensureCompletedStructures();
+    els.opsPhaseChips.innerHTML = '';
+    // PATCH rm-toggle: logique "seulement la courante" retirée
+    if (!Number.isInteger(runtime.focusedOperator)) runtime.focusedOperator = state.defaultOperatorIndex;
+    if (runtime.focusedOperator < 0 || runtime.focusedOperator >= state.operators.length) runtime.focusedOperator = state.defaultOperatorIndex;
+    if (!state.multiView) runtime.focusedOperator = state.defaultOperatorIndex;
+    if (!state.operators[runtime.focusedOperator] && runtime.focusedOperator !== state.defaultOperatorIndex) {
+      runtime.focusedOperator = state.defaultOperatorIndex;
+    }
+    state.operators.forEach((op, idx) => {
+      if (!state.multiView && idx !== state.defaultOperatorIndex) return;
+      if (!op && idx !== state.defaultOperatorIndex) return;
+
+      const operatorName = getCurrentOperatorName(idx);
+
+      // PATCH SMED — stats en-tête opérateur
+      const stats = computeOpPhaseStats(idx, state.activePhase);
+      const ratio = stats.targetMs ? (stats.realMs / stats.targetMs) : 0;
+      let timeClass = 'time-ok';
+      if (ratio > 1) timeClass = 'time-bad';
+      else if (ratio > 0.85) timeClass = 'time-warn';
+
+      const col = document.createElement('div');
+      col.className = 'op-col';
+      col.dataset.index = idx;
+
+      const badge = document.createElement('button');
+      badge.type = 'button';
+      badge.className = 'operator-badge' + (idx === runtime.focusedOperator ? ' focused' : '');
+      badge.textContent = operatorName;
+      badge.addEventListener('click', () => { runtime.focusedOperator = idx; renderOperatorColumns(); });
+      col.appendChild(badge);
+
+      // PATCH op-event — pastille sous le nom
+      const evtBtn = document.createElement('button');
+      evtBtn.type = 'button';
+      evtBtn.className = 'op-evt-btn';
+      evtBtn.textContent = "Évènement HC";
+      evtBtn.addEventListener('click', (e)=> {
+        e.stopPropagation();
+        openOperatorEventMenu(idx, evtBtn);
+      });
+      col.appendChild(evtBtn);
+
+      const card = document.createElement('div');
+      card.className = 'operator-card' + (idx === runtime.focusedOperator ? ' focused' : '');
+      card.dataset.index = idx;
+
+      card.addEventListener('click', e => {
+        if (e.target.closest('.op-pill')) return;
+        runtime.focusedOperator = idx;
+        renderOperatorColumns();
+      });
+
+      const phaseOps = (state.phases[state.activePhase] || []).filter(operation => {
+        if (operation.enabled === false) return false;
+        const assignedIndex = typeof operation.operatorIndex === 'number' ? operation.operatorIndex : state.defaultOperatorIndex;
+        return assignedIndex === idx;
+      });
+
+      const completedSetForPhase = state.completedOpsByOp[operatorName][state.activePhase];
+
+      card.innerHTML = `<div class="operator-header">
+          <h3>${escapeHtml(operatorName)}</h3>
+          <span class="progress-text">${stats.percent}%</span>
+          <div class="meta-line" style="grid-column:1/-1;">
+            <span class="label-muted">${stats.percent}%</span>
+            <span class="time badge ${timeClass}">
+              ${formatDuration(stats.realMs)} / ${formatDuration(stats.targetMs)}
+            </span>
+          </div>
+          <div class="meter" style="grid-column:1/-1;">
+            <div class="fill" style="width:${Math.min(100, Math.round((stats.realMs/(stats.targetMs||1))*100))}%;"></div>
+          </div>
+        </div>`;
+
+      const doneOps = [];
+      const todoOps = [];
+
+      phaseOps.forEach((operation, opIndex) => {
+        if (!operation.id) operation.id = newId();
+        const isDone = completedSetForPhase.has(operation.id || operation.name);
+        const target = isDone ? doneOps : todoOps;
+        target.push({ operation, opIndex, isDone });
+      });
+
+      const buildPill = (operation, opIndex, isDone) => {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'op-item';
+
+        const head = document.createElement('div');
+        head.className = 'op-item-head';
+
+        const pill = document.createElement('button');
+        pill.type = 'button';
+        pill.className = 'op-pill';
+        if (isDone) pill.classList.add('done');
+        const indexSpan = document.createElement('span');
+        indexSpan.className = 'index';
+        indexSpan.textContent = opIndex + 1;
+        const nameSpan = document.createElement('span');
+        nameSpan.textContent = operation.name || '';
+        const checkSpan = document.createElement('span');
+        checkSpan.className = 'check';
+        checkSpan.textContent = '✔';
+        const actionsWrap = document.createElement('div');
+        actionsWrap.className = 'pill-actions';
+        const noteBtn = document.createElement('button');
+        noteBtn.type = 'button';
+        noteBtn.className = 'note-btn';
+        noteBtn.setAttribute('aria-label', `Note pour ${operation.name || 'opération'}`);
+        noteBtn.title = 'Ajouter une note';
+        noteBtn.textContent = 'Note';
+        if (operationHasNote(operation.id)) {
+          noteBtn.classList.add('has-note');
+        }
+        noteBtn.addEventListener('click', event => {
+          event.preventDefault();
+          event.stopPropagation();
+          handleOperationNote(idx, operation);
+        });
+        actionsWrap.appendChild(noteBtn);
+        pill.appendChild(indexSpan);
+        pill.appendChild(nameSpan);
+        pill.appendChild(checkSpan);
+        pill.appendChild(actionsWrap);
+        pill.addEventListener('click', () => validateOperation(idx, operation));
+
+        const hasDetails = !!(operation.details && operation.details.trim());
+
+        const detailPanel = document.createElement('div');
+        detailPanel.className = 'op-details';
+        const detailsId = `${operation.id}-details`;
+        detailPanel.id = detailsId;
+        detailPanel.innerHTML = formatDetailsHtml(operation.details || '');
+        detailPanel.hidden = true;
+        if (hasDetails) {
+          const detailsBtn = document.createElement('button');
+          detailsBtn.type = 'button';
+          detailsBtn.className = 'pill-action pill-action--ghost';
+          detailsBtn.textContent = 'Détails';
+          detailsBtn.title = 'Afficher les détails';
+          detailsBtn.setAttribute('aria-expanded', 'false');
+          detailsBtn.setAttribute('aria-controls', detailsId);
+          detailsBtn.addEventListener('click', event => {
+            event.preventDefault();
+            event.stopPropagation();
+            const willOpen = detailPanel.hidden;
+            detailPanel.hidden = !willOpen;
+            detailPanel.classList.toggle('open', willOpen);
+            detailsBtn.setAttribute('aria-expanded', String(willOpen));
+          });
+          actionsWrap.appendChild(detailsBtn);
+        }
+
+        head.appendChild(pill);
+        wrapper.appendChild(head);
+        wrapper.appendChild(detailPanel);
+
+        return { wrapper, pill };
+      };
+
+      if (doneOps.length) {
+        const doneDetails = document.createElement('details');
+        doneDetails.className = 'done-group';
+        const summary = document.createElement('summary');
+        summary.innerHTML = 'Réalisées <span class="count">(' + doneOps.length + ')</span>';
+        const doneList = document.createElement('div');
+        doneList.className = 'done-list';
+        doneOps.forEach(({ operation, opIndex }) => {
+          const { wrapper } = buildPill(operation, opIndex, true);
+          doneList.appendChild(wrapper);
+        });
+        doneDetails.append(summary, doneList);
+        card.appendChild(doneDetails);
+      }
+
+      const list = document.createElement('div');
+      list.className = 'op-list';
+      let firstPending = true;
+
+      todoOps.forEach(({ operation, opIndex }) => {
+        const { wrapper, pill } = buildPill(operation, opIndex, false);
+        if (firstPending) {
+          pill.classList.add('current');
+          firstPending = false;
+        }
+        list.appendChild(wrapper);
+      });
+
+      if (!phaseOps.length) {
+        const empty = document.createElement('div');
+        empty.className = 'label-muted';
+        empty.textContent = 'Aucune opération';
+        list.appendChild(empty);
+      }
+
+      card.appendChild(list);
+      col.appendChild(card);
+      els.opsPhaseChips.appendChild(col);
+    });
+    if (runtime.shouldScrollToCurrent) {
+      runtime.shouldScrollToCurrent = false;
+      requestAnimationFrame(scrollCurrentOperationIntoView);
+    }
+  }
+
+  function scrollCurrentOperationIntoView() {
+    if (!els.opsPhaseChips) return;
+    const selector = `.operator-card[data-index="${runtime.focusedOperator}"] .op-pill.current`;
+    const target = els.opsPhaseChips.querySelector(selector) || els.opsPhaseChips.querySelector('.op-pill.current');
+    if (target) {
+      target.scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }
+  }
+
+  function operationHasNote(opId) {
+    if (!opId) return false;
+    return state.marks.some(mark => (mark.kind === 'note' || mark.kind === 'op') && mark.opId === opId && mark.note && mark.note.trim());
+  }
+
+  function handleOperationNote(operatorIndex, operation) {
+    if (!operation.id) operation.id = newId();
+    const operatorName = getCurrentOperatorName(operatorIndex);
+    const existingOpMark = state.marks.find(mark => mark.kind === 'op' && mark.opId === operation.id);
+    const existingNoteIndex = state.marks.findIndex(mark => mark.kind === 'note' && mark.opId === operation.id);
+    const currentText = existingNoteIndex >= 0
+      ? state.marks[existingNoteIndex].note
+      : existingOpMark?.note || '';
+    const input = prompt(`Note pour ${operation.name}`, currentText || '');
+    if (input === null) return;
+    const trimmed = input.trim();
+    if (!trimmed) {
+      if (existingNoteIndex >= 0) {
+        state.marks.splice(existingNoteIndex, 1);
+      }
+      if (existingOpMark) existingOpMark.note = '';
+      saveState();
+      renderLog();
+      renderOperatorColumns();
+      updateAnalysisDelayed();
+      return;
+    }
+    const timestamp = getSessionElapsed();
+    if (existingNoteIndex >= 0) {
+      const mark = state.marks[existingNoteIndex];
+      mark.note = trimmed;
+      mark.label = operation.name;
+      mark.phase = state.activePhase;
+      mark.operator = operatorName;
+      mark.t = timestamp;
+      mark.hc = state.activePhase === 'Activité CHGT de PO';
+    } else {
+      state.marks.push({
+        t: timestamp,
+        phase: state.activePhase,
+        operator: operatorName,
+        label: operation.name,
+        kind: 'note',
+        note: trimmed,
+        hc: state.activePhase === 'Activité CHGT de PO',
+        durationMs: 0,
+        opId: operation.id
+      });
+    }
+    if (existingOpMark) {
+      existingOpMark.note = trimmed;
+    }
+    saveState();
+    renderLog();
+    renderOperatorColumns();
+    updateAnalysisDelayed();
+  }
+
+  function validateOperation(operatorIndex, operation) {
+    runtime.focusedOperator = operatorIndex;
+    const operatorName = getCurrentOperatorName(operatorIndex);
+    ensureCompletedStructures();
+    const completedSet = state.completedOpsByOp[operatorName][state.activePhase];
+    if (!operation.id) operation.id = newId();
+    if (completedSet.has(operation.id)) return;
+    const previousTime = state.marks.length ? state.marks[state.marks.length-1].t : 0;
+    const nowElapsed = getSessionElapsed();
+    const duration = Math.max(0, nowElapsed - previousTime);
+    if (completedSet.has(operation.name)) completedSet.delete(operation.name);
+    completedSet.add(operation.id);
+    state.marks.push({
+      t: nowElapsed,
+      phase: state.activePhase,
+      operator: operatorName,
+      label: operation.name,
+      opId: operation.id,
+      kind: 'op',
+      note: '',
+      hc: state.activePhase === 'Activité CHGT de PO',
+      durationMs: duration
+    });
+    saveState();
+    runtime.shouldScrollToCurrent = true;
+    renderOperatorColumns();
+    renderLog();
+    updateAnalysisDelayed();
+  }
+
+  function changePhase(phase) {
+    if (!phasesList.includes(phase)) return;
+    if (state.activePhase === phase) return;
+    const previousPhase = state.activePhase;
+    if (state.runningSince) {
+      const now = Date.now();
+      const delta = now - state.runningSince;
+      state.sessionElapsedMs += delta;
+      if (previousPhase === 'Activité CHGT de PO') {
+        state.prepaElapsedMs += delta;
+      } else {
+        state.elapsedMs += delta;
+      }
+      state.runningSince = now;
+    }
+    state.activePhase = phase;
+    const hasStarted = state.marks.some(m => m.kind === 'start');
+    if (els.start) {
+      if (phase === 'Activité CHGT de PO') {
+        els.start.disabled = true;
+        els.start.classList.remove('primary');
+        els.start.classList.add('secondary');
+        els.start.innerHTML = '<span class="icon">▶</span>Démarrer';
+        els.state.textContent = 'Phase hors chrono';
+      } else {
+        els.start.classList.add('primary');
+        els.start.classList.remove('secondary');
+        if (hasStarted) {
+          els.start.disabled = true;
+          els.start.innerHTML = 'En cours';
+        } else {
+          els.start.disabled = false;
+          els.start.innerHTML = '<span class="icon">▶</span>Démarrer';
+        }
+      }
+    }
+    state.marks.push({
+      t: getSessionElapsed(),
+      phase,
+      label: `Changement de phase vers ${phase}`,
+      kind: 'event',
+      hc: phase === 'Activité CHGT de PO'
+    });
+    renderPhaseChips();
+    renderOperatorColumns();
+    renderLog();
+    updateDisplay();
+    saveState();
+    updateAnalysisDelayed();
+  }
+
+  function getSessionElapsed() {
+    return state.sessionElapsedMs + (state.runningSince ? Date.now() - state.runningSince : 0);
+  }
+
+  function startTimer() {
+    if (state.activePhase === 'Activité CHGT de PO') {
+      showToast('Phase hors chrono : démarrage indisponible', 'info');
+      return;
+    }
+    if (state.runningSince) return;
+    const alreadyStarted = state.marks.some(mark => mark.kind === 'start');
+    if (alreadyStarted) return;
+    state.sessionStart = Date.now();
+    state.runningSince = Date.now();
+    runtime.lastTick = performance.now();
+    state.marks.push({
+      t: getSessionElapsed(),
+      phase: state.activePhase,
+      label: 'Chrono démarré',
+      kind: 'start',
+      note: '',
+      hc: false,
+      durationMs: 0,
+      operator: ''
+    });
+    if (els.start) {
+      els.start.disabled = true;
+      els.start.classList.add('primary');
+      els.start.classList.remove('secondary');
+      els.start.innerHTML = 'En cours';
+    }
+    requestTick();
+    saveState();
+    renderLog();
+    updateDisplay();
+    showToast('Chrono démarré');
+  }
+
+  function requestTick() {
+    cancelAnimationFrame(runtime.animationFrame);
+    if (state.runningSince) {
+      runtime.animationFrame = requestAnimationFrame(tick);
+    }
+  }
+
+  function tick(now) {
+    runtime.lastTick = now;
+    if (state.runningSince) {
+      updateDisplay();
+      runtime.animationFrame = requestAnimationFrame(tick);
+    }
+  }
+
+  function updateDisplay() {
+    const targetMs = totalTargetMinutes()*60000;
+    const currentElapsed = computeElapsedMs();
+    const base = state.mode === 'down' ? Math.max(0, targetMs - currentElapsed) : currentElapsed;
+    els.display.textContent = formatDuration(base);
+    const warnMs = Number(state.alertMin || (totalTargetMinutes()*0.85))*60000;
+    const pct = targetMs ? Math.min(100, (currentElapsed/targetMs)*100) : 0;
+    els.progress.style.width = `${Math.min(100, pct)}%`;
+    els.progress.style.background = currentElapsed <= warnMs ? 'var(--accent)' : currentElapsed <= targetMs ? 'var(--warn)' : 'var(--danger)';
+    if (state.activePhase === 'Activité CHGT de PO') {
+      els.state.textContent = 'Phase hors chrono';
+    } else {
+      if (state.runningSince) {
+        els.state.textContent = 'En cours';
+      } else if (state.marks.some(m => m.kind === 'end')) {
+        els.state.textContent = 'Terminé';
+      } else {
+        els.state.textContent = 'Prêt';
+      }
+    }
+    els.targetMin.textContent = totalTargetMinutes().toFixed(1);
+    els.warnMin.textContent = Number(state.alertMin || (totalTargetMinutes()*0.85)).toFixed(1);
+  }
+
+  function computeElapsedMs() {
+    if (state.runningSince && state.activePhase !== 'Activité CHGT de PO') {
+      return state.elapsedMs + (Date.now() - state.runningSince);
+    }
+    return state.elapsedMs;
+  }
+
+  function addEvent(label, options = {}) {
+    state.marks.push({
+      t: getSessionElapsed(),
+      phase: state.activePhase,
+      operator: options.operator,
+      label,
+      kind: options.kind || 'event',
+      note: options.note || '',
+      hc: state.activePhase === 'Activité CHGT de PO',
+      durationMs: 0
+    });
+    saveState();
+    renderLog();
+    updateAnalysisDelayed();
+  }
+
+  function openQuickEventMenu() {
+    if (runtime.quickEventMenu) {
+      closeQuickEventMenu();
+      return;
+    }
+    const available = state.events.filter(label => label && label.trim());
+    if (!available.length) {
+      const manual = prompt("Libellé de l'événement :");
+      if (manual && manual.trim()) addEvent(manual.trim());
+      return;
+    }
+    const menu = document.createElement('div');
+    menu.className = 'quick-event-menu';
+    menu.setAttribute('role', 'menu');
+    available.forEach(label => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.textContent = label;
+      btn.addEventListener('click', () => {
+        addEvent(label);
+        closeQuickEventMenu();
+      });
+      menu.appendChild(btn);
+    });
+    const custom = document.createElement('button');
+    custom.type = 'button';
+    custom.textContent = 'Autre…';
+    custom.addEventListener('click', () => {
+      const manual = prompt("Libellé de l'événement :");
+      if (manual && manual.trim()) addEvent(manual.trim());
+      closeQuickEventMenu();
+    });
+    menu.appendChild(custom);
+    document.body.appendChild(menu);
+    const rect = els.lap.getBoundingClientRect();
+    menu.style.top = `${rect.bottom + window.scrollY + 8}px`;
+    menu.style.left = `${rect.left + window.scrollX}px`;
+    runtime.quickEventMenu = menu;
+    document.addEventListener('click', handleQuickEventOutside, true);
+    document.addEventListener('keydown', handleQuickEventKeydown);
+    if (els.lap) els.lap.setAttribute('aria-expanded', 'true');
+  }
+
+  function closeQuickEventMenu() {
+    if (!runtime.quickEventMenu) return;
+    runtime.quickEventMenu.remove();
+    runtime.quickEventMenu = null;
+    document.removeEventListener('click', handleQuickEventOutside, true);
+    document.removeEventListener('keydown', handleQuickEventKeydown);
+    if (els.lap) els.lap.setAttribute('aria-expanded', 'false');
+  }
+
+  function handleQuickEventOutside(event) {
+    if (!runtime.quickEventMenu) return;
+    if (runtime.quickEventMenu.contains(event.target) || (els.lap && els.lap.contains(event.target))) return;
+    closeQuickEventMenu();
+  }
+
+  function handleQuickEventKeydown(event) {
+    if (event.key === 'Escape') {
+      closeQuickEventMenu();
+    }
+  }
+
+  // PATCH op-event — ouvre le menu d'événements pour 1 opérateur
+  function openOperatorEventMenu(operatorIndex, anchorEl){
+    closeQuickEventMenu();
+    const available = state.events.filter(l => l && l.trim());
+    const menu = document.createElement('div');
+    menu.className = 'quick-event-menu';
+    menu.setAttribute('role','menu');
+
+    const add = (label) => {
+      addOperatorHCEvent(operatorIndex, label);
+      closeQuickEventMenu();
+    };
+
+    if (available.length){
+      available.forEach(label=>{
+        const b = document.createElement('button');
+        b.type='button'; b.textContent=label; b.addEventListener('click', ()=>add(label));
+        menu.appendChild(b);
+      });
+    }
+    const custom = document.createElement('button');
+    custom.type='button'; custom.textContent='Autre…';
+    custom.addEventListener('click', ()=>{
+      const manual = prompt("Libellé de l'événement HC :");
+      if (manual && manual.trim()) add(manual.trim());
+    });
+    menu.appendChild(custom);
+
+    document.body.appendChild(menu);
+    const r = anchorEl.getBoundingClientRect();
+    menu.style.top = `${r.bottom + window.scrollY + 8}px`;
+    menu.style.left = `${r.left + window.scrollX}px`;
+    runtime.quickEventMenu = menu;
+    document.addEventListener('click', handleQuickEventOutside, true);
+    document.addEventListener('keydown', handleQuickEventKeydown);
+  }
+
+  // PATCH op-event — enregistre l'événement HC pour l'opérateur
+  function addOperatorHCEvent(operatorIndex, label){
+    const operatorName = getCurrentOperatorName(operatorIndex);
+    state.marks.push({
+      t: getSessionElapsed(),
+      phase: 'Activité CHGT de PO',
+      operator: operatorName,
+      label: label,
+      kind: 'event',
+      note: '',
+      hc: true,
+      durationMs: 0
+    });
+    saveState();
+    renderLog();
+    renderOperatorColumns();
+    updateAnalysisDelayed();
+    showToast(`Événement HC ajouté pour ${operatorName}`);
+  }
+
+  async function finishChange() {
+    if (state.marks.some(m => m.kind === 'end')) return;
+    if (state.runningSince) {
+      const now = Date.now();
+      const delta = now - state.runningSince;
+      state.sessionElapsedMs += delta;
+      if (state.activePhase === 'Activité CHGT de PO') {
+        state.prepaElapsedMs += delta;
+      } else {
+        state.elapsedMs += delta;
+      }
+      state.runningSince = null;
+    }
+    addEvent('Fin du changement', { kind: 'end' });
+    cancelAnimationFrame(runtime.animationFrame);
+    updateDisplay();
+    showToast('Changement terminé');
+    const poSafe = (state.po && state.po.trim() ? state.po.trim() : 'PO').replace(/[^\w-]+/g, '_') || 'PO';
+    const lineSafe = (state.line && state.line.trim() ? state.line.trim() : 'L29').replace(/[^\w-]+/g, '_') || 'L29';
+    const stamp = new Date().toISOString().slice(0, 16).replace(/:/g, '-');
+    const filename = `SMED_${lineSafe}_${poSafe}_${stamp}.html`;
+    await exportHtml({ filename, forceSave: true });
+  }
+
+  function renderLog() {
+    els.logTable.innerHTML = '';
+    let previousTime = 0;
+    let totalChrono = 0;
+    state.marks.sort((a,b) => a.t - b.t);
+    state.marks.forEach((mark, index) => {
+      const row = document.createElement('tr');
+      const duration = mark.durationMs || Math.max(0, mark.t - previousTime);
+      if (!mark.hc && mark.kind !== 'start') {
+        totalChrono += duration;
+      }
+      row.innerHTML = `
+        <td>${index + 1}</td>
+        <td>${formatDuration(mark.t)}</td>
+        <td>${formatDuration(duration)}</td>
+        <td>${mark.hc ? '<span class="badge hc">HC</span>' : 'Non'}</td>
+        <td>${escapeHtml(mark.phase)}</td>
+        <td>${escapeHtml(mark.operator || '')}</td>
+        <td>${escapeHtml(mark.label)}</td>
+        <td class="note-cell" contenteditable="true" data-index="${index}">${escapeHtml(mark.note || '')}</td>
+      `;
+      els.logTable.appendChild(row);
+      previousTime = mark.t;
+    });
+    els.totalCell.textContent = formatDuration(totalChrono);
+    els.logCount.textContent = `${state.marks.length} entrées`;
+  }
+
+  function handleNoteEdit(event) {
+    const cell = event.target;
+    if (!cell.matches('[contenteditable="true"]')) return;
+    const index = Number(cell.dataset.index);
+    if (!Number.isFinite(index)) return;
+    state.marks[index].note = cell.textContent.trim();
+    saveState();
+    renderOperatorColumns();
+    updateAnalysisDelayed();
+  }
+
+  function exportCsv() {
+    const target = totalTargetMinutes();
+    const headers = ['date_session','line','po','mode','hors_chrono','target_min_global','idx','horodatage','duree_ms','duree_hms','operateur','phase','evenement','note'];
+    const rows = state.marks.map((mark, idx) => [
+      new Date(state.sessionStart).toISOString(),
+      state.line,
+      state.po,
+      state.mode,
+      mark.hc ? 'true' : 'false',
+      target.toFixed(1),
+      idx + 1,
+      formatDuration(mark.t),
+      Math.max(0, mark.durationMs || 0),
+      formatDuration(mark.durationMs || 0),
+      mark.operator || '',
+      mark.phase,
+      mark.label,
+      mark.note || ''
+    ]);
+    const csv = [headers.join(';')].concat(rows.map(r => r.map(value => `"${String(value).replace(/"/g,'""')}"`).join(';'))).join('\n');
+    const rawLine = state.line && state.line.trim() ? state.line.trim() : 'L29';
+    const lineSegment = rawLine.replace(/[^\w-]+/g, '_') || 'L29';
+    const stamp = new Date().toISOString().slice(0,16).replace(/:/g, '-');
+    downloadFile(`smed_${lineSegment}_${stamp}.csv`, `\uFEFF${csv}`, 'text/csv;charset=utf-8');
+  }
+
+  async function exportHtml(options = {}) {
+    const rawLineLabel = state.line && state.line.trim() ? state.line.trim() : 'L29';
+    const reportLine = escapeHtml(rawLineLabel);
+    const lineSegment = rawLineLabel.replace(/[^\w-]+/g, '_') || 'L29';
+    const template = `<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="utf-8">
+<title>Rapport SMED ${reportLine}</title>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+:root{color-scheme:light;}
+body{font-family:"Inter","Segoe UI",sans-serif;margin:40px;background:#f4f6fb;color:#0f1a34;}
+.report-header{display:flex;justify-content:space-between;align-items:flex-start;gap:20px;border-bottom:2px solid #d6def0;padding-bottom:16px;margin-bottom:32px;}
+.report-header h1{margin:0;font-size:26px;color:#0b1533;}
+.report-header .meta{margin:4px 0 0;color:#5b6380;font-size:14px;}
+.report-header .chip{background:#0b1533;color:#fff;padding:10px 18px;border-radius:999px;font-weight:600;}
+.section{margin-bottom:32px;}
+.section h2{margin:0 0 12px;font-size:20px;color:#0b1533;}
+.kpi-grid{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));}
+.kpi-card{background:#fff;border-radius:16px;padding:18px;border:1px solid #dbe3f6;box-shadow:0 10px 25px rgba(15,26,52,.08);}
+.kpi-card span{font-size:12px;letter-spacing:0.08em;color:#6c7693;text-transform:uppercase;}
+.kpi-card strong{display:block;margin-top:8px;font-size:20px;color:#0f1a34;}
+.data-table{width:100%;border-collapse:collapse;margin-top:12px;}
+.data-table th,.data-table td{border:1px solid #dbe3f6;padding:10px 12px;font-size:13px;text-align:left;}
+.data-table th{background:#eef2fc;font-size:12px;letter-spacing:0.06em;text-transform:uppercase;color:#4c5675;}
+.list-grid{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));}
+.list-grid article{background:#fff;border:1px solid #dbe3f6;border-radius:14px;padding:16px;display:grid;gap:10px;}
+.list-grid h3{margin:0;font-size:15px;color:#0b1533;}
+.list-grid ul{margin:0;padding-left:20px;display:grid;gap:6px;}
+.list-grid li{color:#0f1a34;font-size:14px;}
+.prepa-card{background:#fff;border:1px solid #dbe3f6;border-radius:16px;padding:18px;display:grid;gap:10px;}
+.badge{display:inline-block;padding:4px 10px;border-radius:999px;background:#eef2fc;color:#3a4a7a;font-size:12px;}
+.badge.hc{background:#ffe8cc;color:#ad5a00;}
+.muted{color:#6c7693;font-style:italic;}
+.journal-table{width:100%;border-collapse:collapse;margin-top:16px;}
+.journal-table th,.journal-table td{border:1px solid #dbe3f6;padding:8px 10px;font-size:12px;text-align:left;}
+.journal-table th{background:#eef2fc;letter-spacing:0.06em;text-transform:uppercase;color:#4c5675;}
+.journal-table td .badge{font-size:11px;}
+@media print{body{margin:20mm;background:#fff;color:#000;} .report-header{border-color:#c5cee4;} .kpi-card,.prepa-card,.list-grid article{box-shadow:none;} a{color:inherit;}}
+</style>
+</head>
+<body>
+${buildReportHtml()}
+</body>
+</html>`;
+    const filename = options.filename || `smed_${lineSegment}_${Date.now()}.html`;
+    if (options.forceSave && typeof window !== 'undefined' && window.showSaveFilePicker) {
+      try {
+        const handle = await window.showSaveFilePicker({
+          suggestedName: filename,
+          types: [{ description: 'Document HTML', accept: { 'text/html': ['.html'] } }]
+        });
+        const writable = await handle.createWritable();
+        await writable.write(template);
+        await writable.close();
+        showToast('Rapport exporté');
+        return;
+      } catch (err) {
+        console.error('Export HTML annulé ou impossible', err);
+      }
+    }
+    downloadFile(filename, template, 'text/html');
+    if (options.forceSave) {
+      showToast('Rapport exporté');
+    }
+  }
+
+  function downloadFile(filename, content, mime) {
+    const blob = new Blob([content], { type: mime });
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = filename;
+    link.style.display = 'none';
+    document.body.appendChild(link);
+    link.click();
+    requestAnimationFrame(() => {
+      URL.revokeObjectURL(link.href);
+      document.body.removeChild(link);
+    });
+  }
+
+  function buildReportHtml() {
+    const analysis = computeAnalysis();
+    const kpi = analysis.kpi;
+    const sessionDate = new Date(state.sessionStart).toLocaleString('fr-FR', { hour12: false });
+    const safePo = escapeHtml(state.po || '—');
+    const safeLine = escapeHtml(state.line || 'Ligne');
+    const modeLabel = state.mode === 'down' ? 'Chrono décroissant' : 'Chrono croissant';
+    const targetMinutes = kpi.target ? (kpi.target / 60000).toFixed(1) : '0.0';
+    const phasesRows = analysis.phases.length
+      ? analysis.phases.map(item => `<tr><td>${escapeHtml(item.phase)}</td><td>${formatDuration(item.duration)}</td><td>${item.percent}%</td><td>${item.gap ? '+' + formatDuration(item.gap) : '—'}</td></tr>`).join('')
+      : '<tr><td colspan="4" class="muted">Aucune phase chronométrée enregistrée</td></tr>';
+    const operatorRows = analysis.operators.length
+      ? analysis.operators.map(item => `<tr><td>${escapeHtml(item.operator)}</td><td>${formatDuration(item.duration)}</td><td>${item.percent}%</td></tr>`).join('')
+      : '<tr><td colspan="3" class="muted">Aucun opérateur chronométré</td></tr>';
+    const topContribList = analysis.topContrib.length
+      ? analysis.topContrib.map(item => `<li>${escapeHtml(item.phase)} · +${formatDuration(item.gap)}</li>`).join('')
+      : '<li class="muted">Aucun dépassement</li>';
+    const topOpsList = analysis.topOps.length
+      ? analysis.topOps.map(item => `<li>${escapeHtml(item.label)} (${escapeHtml(item.phase)}) – ${formatDuration(item.duration)}</li>`).join('')
+      : '<li class="muted">—</li>';
+    const perturbList = analysis.events.length
+      ? analysis.events.map(item => `<li>${escapeHtml(item.label)} (${item.count})</li>`).join('')
+      : '<li class="muted">Aucun événement récurrent</li>';
+    const prepaNotes = analysis.prepa.notes.length
+      ? `<ul>${analysis.prepa.notes.map(note => `<li>${escapeHtml(note)}</li>`).join('')}</ul>`
+      : '<p class="muted">Aucun commentaire</p>';
+    const journalRows = state.marks.length
+      ? state.marks.map((mark, idx) => `<tr><td>${idx + 1}</td><td>${formatDuration(mark.t)}</td><td>${formatDuration(mark.durationMs || 0)}</td><td>${mark.hc ? '<span class="badge hc">HC</span>' : 'Non'}</td><td>${escapeHtml(mark.phase)}</td><td>${escapeHtml(mark.operator || '')}</td><td>${escapeHtml(mark.label)}</td><td>${escapeHtml(mark.note || '')}</td></tr>`).join('')
+      : '<tr><td colspan="8" class="muted">Journal vide</td></tr>';
+    return `
+      <header class="report-header">
+        <div>
+          <h1>Rapport SMED – PO ${safePo}</h1>
+          <p class="meta">Ligne ${safeLine} · ${modeLabel} · Session du ${sessionDate}</p>
+        </div>
+        <div class="chip">Cible globale : ${targetMinutes} min</div>
+      </header>
+      <section class="section">
+        <h2>Indicateurs clés</h2>
+        <div class="kpi-grid">
+          <div class="kpi-card"><span>Durée totale</span><strong>${formatDuration(kpi.total)}</strong></div>
+          <div class="kpi-card"><span>Cible (min)</span><strong>${targetMinutes}</strong></div>
+          <div class="kpi-card"><span>Écart</span><strong>${formatDuration(kpi.gap)}</strong></div>
+          <div class="kpi-card"><span>Gain potentiel</span><strong>${formatDuration(kpi.potential)}</strong></div>
+        </div>
+      </section>
+      <section class="section">
+        <h2>Répartition par phases</h2>
+        <table class="data-table"><thead><tr><th>Phase</th><th>Durée</th><th>%</th><th>Écart vs cible</th></tr></thead><tbody>${phasesRows}</tbody></table>
+      </section>
+      <section class="section">
+        <h2>Répartition par opérateurs</h2>
+        <table class="data-table"><thead><tr><th>Opérateur</th><th>Durée</th><th>%</th></tr></thead><tbody>${operatorRows}</tbody></table>
+      </section>
+      <section class="section">
+        <h2>Analyse qualitative</h2>
+        <div class="list-grid">
+          <article><h3>Top contributeurs à l'écart</h3><ul>${topContribList}</ul></article>
+          <article><h3>Top opérations longues</h3><ul>${topOpsList}</ul></article>
+          <article><h3>Perturbateurs fréquents</h3><ul>${perturbList}</ul></article>
+        </div>
+      </section>
+      <section class="section">
+        <h2>Prépa (HC)</h2>
+        <div class="prepa-card">
+          <div><span class="badge hc">HC</span> Checklist complétée à <strong>${analysis.prepa.percent}%</strong></div>
+          <div>Temps total hors chrono : <strong>${formatDuration(analysis.prepa.duration)}</strong></div>
+          <div>Commentaires :</div>
+          ${prepaNotes}
+        </div>
+      </section>
+      <section class="section">
+        <h2>Journal des événements</h2>
+        <table class="journal-table"><thead><tr><th>#</th><th>Horodatage</th><th>Durée</th><th>HC</th><th>Phase</th><th>Opérateur</th><th>Libellé</th><th>Note</th></tr></thead><tbody>${journalRows}</tbody></table>
+      </section>
+    `;
+  }
+
+  function computeAnalysis() {
+    const phaseDurations = new Map();
+    const operatorDurations = new Map();
+    const events = new Map();
+    let previousTime = 0;
+    let totalChrono = 0;
+    const gapSource = [];
+    let phaseContext = state.marks.length ? state.marks[0].phase : state.activePhase;
+    state.marks.forEach(mark => {
+      const duration = mark.durationMs || Math.max(0, mark.t - previousTime);
+      const isPhaseChange = mark.kind === 'event' && mark.label?.toLowerCase().includes('changement de phase');
+      const attributedPhase = isPhaseChange ? phaseContext : mark.phase;
+      const attributedHc = attributedPhase === 'Activité CHGT de PO';
+      if (!attributedHc) {
+        totalChrono += duration;
+        phaseDurations.set(attributedPhase, (phaseDurations.get(attributedPhase) || 0) + duration);
+        if (mark.operator) {
+          operatorDurations.set(mark.operator, (operatorDurations.get(mark.operator) || 0) + duration);
+        }
+        if (mark.kind === 'op') {
+          gapSource.push({ phase: attributedPhase, label: mark.label, duration });
+        }
+      }
+      if (mark.kind === 'event' && mark.label && !isPhaseChange) {
+        events.set(mark.label, (events.get(mark.label) || 0) + 1);
+      }
+      previousTime = mark.t;
+      phaseContext = mark.phase;
+    });
+    const targetMs = totalTargetMinutes() * 60000;
+    const gapMs = Math.max(0, totalChrono - targetMs);
+    const potential = gapMs > 0 ? gapMs : Math.max(0, targetMs - totalChrono);
+    const phases = Array.from(phaseDurations.entries()).filter(([phase]) => timedPhases.includes(phase)).map(([phase, duration]) => ({
+      phase,
+      duration,
+      percent: totalChrono ? Math.round((duration/totalChrono)*100) : 0,
+      gap: Math.max(0, duration - targetMinutesForPhase(phase)*60000)
+    })).sort((a,b) => b.duration - a.duration);
+    const operators = Array.from(operatorDurations.entries()).map(([operator,duration]) => ({
+      operator,
+      duration,
+      percent: totalChrono ? Math.round((duration/totalChrono)*100) : 0
+    })).sort((a,b) => b.duration - a.duration);
+    const topContrib = phases.filter(p => p.gap > 0).sort((a,b) => b.gap - a.gap).slice(0,3);
+    const topOps = gapSource.filter(item => timedPhases.includes(item.phase)).sort((a,b) => b.duration - a.duration).slice(0,3);
+    const eventsList = Array.from(events.entries()).map(([label,count]) => ({ label, count })).sort((a,b) => b.count - a.count);
+    const prepaMarks = state.marks.filter(m => m.phase === 'Activité CHGT de PO');
+    const prepaCompleted = prepaMarks.filter(m => m.kind === 'op').length;
+    const prepaOps = (state.phases['Activité CHGT de PO'] || []).filter(op => op.enabled !== false);
+    const prepaTotal = prepaOps.length || 1;
+    const prepaNotes = [];
+    prepaMarks.forEach(mark => {
+      if (mark.note && mark.note.trim() && !prepaNotes.includes(mark.note.trim())) {
+        prepaNotes.push(mark.note.trim());
+      }
+    });
+    return {
+      kpi: {
+        total: totalChrono,
+        target: targetMs,
+        gap: gapMs,
+        potential
+      },
+      phases,
+      operators,
+      topContrib,
+      topOps,
+      events: eventsList,
+      prepa: {
+        percent: Math.round((prepaCompleted / prepaTotal) * 100),
+        duration: state.prepaElapsedMs,
+        notes: prepaNotes
+      }
+    };
+  }
+
+  function collectSessionMetrics() {
+    const phaseDurations = new Map();
+    const operationDurations = new Map();
+    const eventStats = new Map();
+    let previousTime = 0;
+    let totalTimedMs = 0;
+    let totalTimelineMs = 0;
+    let vaMs = 0;
+    let imprevusMs = 0;
+    let nonVaMs = 0;
+    let phaseContext = state.marks.length ? state.marks[0].phase : state.activePhase;
+    const hasMarks = state.marks.length > 0;
+    let hasHcMarks = false;
+
+    state.marks.forEach(mark => {
+      const duration = mark.durationMs || Math.max(0, mark.t - previousTime);
+      const isPhaseChange = mark.kind === 'event' && mark.label && mark.label.toLowerCase().includes('changement de phase');
+      const attributedPhase = isPhaseChange ? phaseContext : (mark.phase || phaseContext);
+      const isTimedPhase = timedPhases.includes(attributedPhase);
+      const isHc = mark.hc || attributedPhase === 'Activité CHGT de PO';
+      if (isHc) hasHcMarks = true;
+
+      totalTimelineMs += duration;
+
+      if (isTimedPhase && !isHc) {
+        totalTimedMs += duration;
+        phaseDurations.set(attributedPhase, (phaseDurations.get(attributedPhase) || 0) + duration);
+        if (mark.kind === 'op') {
+          vaMs += duration;
+          if (mark.opId) {
+            operationDurations.set(mark.opId, (operationDurations.get(mark.opId) || 0) + duration);
+          }
+        } else if (mark.kind === 'event' && !isPhaseChange) {
+          imprevusMs += duration;
+          if (mark.label) {
+            const current = eventStats.get(mark.label) || { count: 0, totalMs: 0 };
+            current.count += 1;
+            current.totalMs += duration;
+            eventStats.set(mark.label, current);
+          }
+        } else {
+          nonVaMs += duration;
+        }
+      } else {
+        nonVaMs += duration;
+        if (mark.kind === 'event' && mark.label && !isPhaseChange) {
+          const current = eventStats.get(mark.label) || { count: 0, totalMs: 0 };
+          current.count += 1;
+          current.totalMs += duration;
+          eventStats.set(mark.label, current);
+        }
+      }
+
+      previousTime = mark.t;
+      phaseContext = mark.phase || attributedPhase;
+    });
+
+    if (!hasMarks) {
+      totalTimedMs = state.elapsedMs || 0;
+      totalTimelineMs = totalTimedMs + (state.prepaElapsedMs || 0);
+      vaMs = totalTimedMs;
+      nonVaMs += state.prepaElapsedMs || 0;
+    } else if (!hasHcMarks && state.prepaElapsedMs) {
+      nonVaMs += state.prepaElapsedMs;
+      totalTimelineMs += state.prepaElapsedMs;
+    } else {
+      totalTimelineMs = Math.max(totalTimelineMs, totalTimedMs);
+    }
+
+    // Heuristique :
+    //   - opérations (kind === 'op') = Valeur Ajoutée
+    //   - événements = Imprévus
+    //   - le reste (dont HC) = Non Valeur Ajoutée
+    return {
+      totalRealMs: totalTimedMs,
+      totalTimelineMs,
+      vaMs,
+      imprevusMs,
+      nonVaMs,
+      phaseDurations,
+      operationDurations,
+      eventStats
+    };
+  }
+
+  function computeKPI(metrics, extras = {}) {
+    const targetMs = totalTargetMinutes() * 60000;
+    const totalMs = metrics.totalRealMs || state.elapsedMs || 0;
+    const gapMs = totalMs - targetMs;
+    const performancePercent = targetMs ? (totalMs / targetMs) * 100 : 0;
+    const gapPercent = targetMs ? (gapMs / targetMs) * 100 : 0;
+    const base = Math.max(metrics.vaMs + metrics.nonVaMs + metrics.imprevusMs, 1);
+    const clampPercent = value => Number.isFinite(value) ? Math.max(0, value) : 0;
+
+    const result = {
+      totalMs,
+      targetMs,
+      gapMs,
+      gapPercent,
+      performancePercent,
+      va: { ms: metrics.vaMs, percent: clampPercent((metrics.vaMs / base) * 100) },
+      nonVa: { ms: metrics.nonVaMs, percent: clampPercent((metrics.nonVaMs / base) * 100) },
+      imprevus: { ms: metrics.imprevusMs, percent: clampPercent((metrics.imprevusMs / base) * 100) },
+      topLosses: []
+    };
+
+    const losses = [];
+    if (Array.isArray(extras.phaseComparison)) {
+      extras.phaseComparison.forEach(item => {
+        if (item.gapMs > 0) {
+          losses.push({ label: `Phase · ${item.phase}`, phase: item.phase, gapMs: item.gapMs });
+        }
+      });
+    }
+    if (Array.isArray(extras.criticalOps)) {
+      extras.criticalOps.forEach(item => {
+        if (item.gapMs > 0) {
+          losses.push({ label: `Opération · ${item.opName}`, phase: item.phase, gapMs: item.gapMs });
+        }
+      });
+    }
+    losses.sort((a, b) => b.gapMs - a.gapMs);
+    result.topLosses = losses.slice(0, 3);
+    return result;
+  }
+
+  function computePhaseComparison(metrics) {
+    return timedPhases.map(phase => {
+      const targetMs = targetMinutesForPhase(phase) * 60000;
+      const realMs = metrics.phaseDurations.get(phase) || 0;
+      const gapMs = realMs - targetMs;
+      const ratioPercent = targetMs ? (realMs / targetMs) * 100 : (realMs > 0 ? 999 : 0);
+      const gapPercent = targetMs ? ((realMs - targetMs) / targetMs) * 100 : (realMs > 0 ? 100 : 0);
+      let colorClass = 'good';
+      if (ratioPercent > 110) colorClass = 'bad';
+      else if (ratioPercent >= 85) colorClass = 'warn';
+      return { phase, realMs, targetMs, gapMs, gapPercent, ratioPercent, colorClass };
+    });
+  }
+
+  function computeCriticalOps(metrics) {
+    const items = [];
+    timedPhases.forEach(phase => {
+      (state.phases[phase] || []).forEach(op => {
+        if (!op || op.enabled === false) return;
+        const targetMs = Number(op.targetMin || 0) * 60000;
+        const realMs = metrics.operationDurations.get(op.id) || 0;
+        const gapMs = realMs - targetMs;
+        const gapPercent = targetMs ? (realMs / targetMs) * 100 : (realMs > 0 ? 999 : 0);
+        items.push({
+          opId: op.id,
+          opName: op.name || 'Sans nom',
+          phase,
+          realMs,
+          targetMs,
+          gapMs,
+          gapPercent,
+          hasFire: gapPercent > 120,
+          details: op.details || ''
+        });
+      });
+    });
+    items.sort((a, b) => (b.gapPercent || 0) - (a.gapPercent || 0));
+    return items;
+  }
+
+  function computePerturbateurs(metrics) {
+    return Array.from(metrics.eventStats.entries()).map(([label, info]) => ({
+      label,
+      count: info.count,
+      totalMs: info.totalMs,
+      hasWarning: info.count >= 3 || info.totalMs >= 5 * 60000
+    })).sort((a, b) => b.totalMs - a.totalMs);
+  }
+
+  function buildSessionSnapshots(phaseComparison) {
+    const snapshots = [];
+    const currentMap = new Map();
+    phaseComparison.forEach(item => currentMap.set(item.phase, item.realMs));
+    snapshots.push({ id: 'current', label: 'Session actuelle', data: currentMap });
+
+    const targetMap = new Map();
+    timedPhases.forEach(phase => {
+      targetMap.set(phase, targetMinutesForPhase(phase) * 60000);
+    });
+    snapshots.push({ id: 'target', label: 'Cible théorique', data: targetMap });
+
+    return snapshots;
+  }
+
+  function generateInsights({ kpi, phaseComparison, criticalOps, perturbateurs }) {
+    const insights = [];
+    if (Number.isFinite(kpi.performancePercent)) {
+      const deltaPercent = kpi.performancePercent - 100;
+      const gapLabel = formatDuration(Math.abs(kpi.gapMs));
+      if (deltaPercent > 0) {
+        insights.push(`La session dépasse la cible de ${gapLabel} (${deltaPercent.toFixed(1)} %).`);
+      } else if (deltaPercent < 0) {
+        insights.push(`La session est en avance de ${gapLabel} (${Math.abs(deltaPercent).toFixed(1)} %).`);
+      }
+    }
+    const mainPhase = [...phaseComparison].sort((a, b) => b.gapMs - a.gapMs)[0];
+    if (mainPhase && mainPhase.gapMs > 0) {
+      insights.push(`Phase prioritaire : ${mainPhase.phase} (+${formatDuration(mainPhase.gapMs)}, ${mainPhase.ratioPercent.toFixed(1)} % du ciblé).`);
+    }
+    const hotOp = criticalOps.find(item => item.hasFire) || criticalOps[0];
+    if (hotOp && hotOp.gapMs > 0) {
+      insights.push(`Opération critique : ${hotOp.opName} (${hotOp.phase}) dépasse de ${formatDuration(hotOp.gapMs)}.`);
+    }
+    const perturb = perturbateurs.find(p => p.hasWarning);
+    if (perturb && insights.length < 3) {
+      insights.push(`Perturbateur récurrent : ${perturb.label} (${perturb.count}×, ${formatDuration(perturb.totalMs)}).`);
+    }
+    if (!insights.length) {
+      insights.push('Aucune dérive notable détectée sur cette session.');
+    }
+    return insights.slice(0, 3);
+  }
+
+  function buildTooltipHTML(phase, realMs, targetMs, gapMs, gapPercent) {
+    const gapLabel = `${gapMs >= 0 ? '+' : '−'}${formatDuration(Math.abs(gapMs))}`;
+    const percentLabel = Number.isFinite(gapPercent) ? `${gapPercent >= 0 ? '+' : '−'}${Math.abs(gapPercent).toFixed(1)}%` : '—';
+    return `<strong>${escapeHtml(phase)}</strong><div>Réel : ${formatDuration(realMs)}</div><div>Cible : ${formatMinutesValue(targetMs)}</div><div>Écart : ${gapLabel} (${percentLabel})</div>`;
+  }
+
+  function renderComparisonChart(snapshots, phases) {
+    if (!els.comparisonChart || !snapshots.length) return;
+    const fallbackA = snapshots[0]?.id || '';
+    const fallbackB = snapshots[1]?.id || fallbackA;
+    if (!snapshots.some(item => item.id === runtime.comparisonA)) runtime.comparisonA = fallbackA;
+    if (!snapshots.some(item => item.id === runtime.comparisonB)) runtime.comparisonB = fallbackB;
+    const sessionA = snapshots.find(item => item.id === runtime.comparisonA);
+    const sessionB = snapshots.find(item => item.id === runtime.comparisonB);
+    if (!sessionA || !sessionB) {
+      els.comparisonChart.textContent = 'Historique insuffisant pour comparer.';
+      return;
+    }
+    const valuesA = phases.map(phase => sessionA.data.get(phase) || 0);
+    const valuesB = phases.map(phase => sessionB.data.get(phase) || 0);
+    const maxValue = Math.max(...valuesA, ...valuesB, 1);
+    const width = 420;
+    const height = 200;
+    const padding = 36;
+    const axisWidth = phases.length > 1 ? (width - padding * 2) / (phases.length - 1) : 0;
+    const points = values => values.map((value, index) => {
+      const x = padding + axisWidth * index;
+      const y = height - padding - (value / maxValue) * (height - padding * 2);
+      return { x: Number.isFinite(x) ? x : padding, y: Number.isFinite(y) ? y : height - padding };
+    });
+    const pathFromPoints = pts => pts.map((pt, idx) => `${idx === 0 ? 'M' : 'L'}${pt.x.toFixed(1)},${pt.y.toFixed(1)}`).join(' ');
+    const ptsA = points(valuesA);
+    const ptsB = points(valuesB);
+    const pathA = pathFromPoints(ptsA);
+    const pathB = pathFromPoints(ptsB);
+    const circlesA = ptsA.map(pt => `<circle cx="${pt.x.toFixed(1)}" cy="${pt.y.toFixed(1)}" r="3" fill="var(--accent)" />`).join('');
+    const circlesB = ptsB.map(pt => `<circle cx="${pt.x.toFixed(1)}" cy="${pt.y.toFixed(1)}" r="3" fill="var(--warn)" />`).join('');
+    const axisLabels = phases.map((phase, idx) => {
+      const x = padding + axisWidth * idx;
+      return `<text x="${x.toFixed(1)}" y="${height - padding + 18}" text-anchor="middle" font-size="11">${escapeHtml(phase)}</text>`;
+    }).join('');
+    const gridLines = [0.25, 0.5, 0.75, 1].map(ratio => {
+      const y = height - padding - ratio * (height - padding * 2);
+      return `<line x1="${padding}" y1="${y.toFixed(1)}" x2="${width - padding}" y2="${y.toFixed(1)}" stroke="rgba(255,255,255,.08)" stroke-width="1" />`;
+    }).join('');
+    const svg = `<svg viewBox="0 0 ${width} ${height}" aria-hidden="true"><g fill="none" stroke="rgba(255,255,255,.12)" stroke-width="1"><line x1="${padding}" y1="${height - padding}" x2="${width - padding}" y2="${height - padding}" /><line x1="${padding}" y1="${padding}" x2="${padding}" y2="${height - padding}" /></g>${gridLines}<path d="${pathA}" fill="none" stroke="var(--accent)" stroke-width="2" />${circlesA}<path d="${pathB}" fill="none" stroke="var(--warn)" stroke-width="2" stroke-dasharray="6 4" />${circlesB}${axisLabels}</svg>`;
+    els.comparisonChart.innerHTML = `${svg}<div class="comparison-legend"><span data-color="accent">${escapeHtml(sessionA.label)}</span><span data-color="warn">${escapeHtml(sessionB.label)}</span></div>`;
+  }
+
+  function renderAdvancedAnalysis() {
+    const metrics = collectSessionMetrics();
+    const phaseComparison = computePhaseComparison(metrics);
+    const criticalOps = computeCriticalOps(metrics);
+    const perturbateurs = computePerturbateurs(metrics);
+    const kpi = computeKPI(metrics, { phaseComparison, criticalOps });
+    const insights = generateInsights({ kpi, phaseComparison, criticalOps, perturbateurs });
+    const analysis = computeAnalysis();
+
+    const cardClass = kpi.performancePercent > 110 ? 'kpi-card--color-bad' : (kpi.performancePercent >= 100 ? 'kpi-card--color-warn' : 'kpi-card--color-good');
+    const gapLabel = formatDuration(Math.abs(kpi.gapMs));
+    const gapPercentLabel = Number.isFinite(kpi.gapPercent) ? `${kpi.gapPercent >= 0 ? '+' : '−'}${Math.abs(kpi.gapPercent).toFixed(1)}%` : '—';
+    const gapSign = kpi.gapMs >= 0 ? '+' : '−';
+    const percentLabel = value => Number.isFinite(value) ? value.toFixed(1) : '0.0';
+
+    els.kpiGrid.innerHTML = `
+      <div class="kpi-card ${cardClass}"><span>Durée vs cible</span><strong>${formatDuration(kpi.totalMs)}</strong><small>Cible : ${formatMinutesValue(kpi.targetMs)}</small><small>Écart : ${gapSign}${gapLabel} (${gapPercentLabel})</small></div>
+      <div class="kpi-card"><span>Valeur ajoutée</span><strong>${percentLabel(kpi.va.percent)}%</strong><small>${formatDuration(kpi.va.ms)}</small></div>
+      <div class="kpi-card"><span>Non valeur ajoutée</span><strong>${percentLabel(kpi.nonVa.percent)}%</strong><small>${formatDuration(kpi.nonVa.ms)}</small></div>
+      <div class="kpi-card"><span>Imprévus</span><strong>${percentLabel(kpi.imprevus.percent)}%</strong><small>${formatDuration(kpi.imprevus.ms)}</small></div>
+    `;
+
+    els.topContrib.innerHTML = kpi.topLosses.length
+      ? kpi.topLosses.map(item => `<li>${escapeHtml(item.label)} · ${formatDuration(item.gapMs)}</li>`).join('')
+      : '<li class="label-muted">Aucune perte identifiée</li>';
+
+    if (els.criticalOpsBody) {
+      if (criticalOps.length) {
+        els.criticalOpsBody.innerHTML = criticalOps.slice(0, 8).map(op => {
+          const gap = `${op.gapMs >= 0 ? '+' : '−'}${formatDuration(Math.abs(op.gapMs))}`;
+          const percent = Number.isFinite(op.gapPercent) ? `${op.gapPercent.toFixed(1)}%` : '—';
+          const note = op.details ? escapeHtml(op.details) : '<span class="label-muted">—</span>';
+          const fire = op.hasFire ? ' <span class="badge badge--fire">🔥</span>' : '';
+          return `<tr><td>${escapeHtml(op.opName)}${fire}</td><td>${escapeHtml(op.phase)}</td><td>${gap} (${percent})</td><td>${note}</td></tr>`;
+        }).join('');
+      } else {
+        els.criticalOpsBody.innerHTML = '<tr><td colspan="4" class="label-muted">Aucune opération mesurée</td></tr>';
+      }
+    }
+
+    els.perturbateurs.innerHTML = perturbateurs.length
+      ? perturbateurs.map(item => `<li><span>${escapeHtml(item.label)}</span><span>${formatDuration(item.totalMs)} · ${item.count}x${item.hasWarning ? ' <span class="badge badge--warn">⚠️</span>' : ''}</span></li>`).join('')
+      : '<li class="label-muted">Aucun perturbateur récurrent</li>';
+
+    els.insightsList.innerHTML = insights.length
+      ? insights.map(text => `<li>${escapeHtml(text)}</li>`).join('')
+      : '<li class="label-muted">Pas encore d\'insight</li>';
+
+    els.phaseDistribution.innerHTML = '';
+    if (phaseComparison.length) {
+      const maxReal = Math.max(...phaseComparison.map(item => item.realMs), 1);
+      phaseComparison.forEach(item => {
+        const width = maxReal ? (item.realMs / maxReal) * 100 : 0;
+        const row = document.createElement('div');
+        row.className = 'bar-row bar-row--enhanced';
+        row.innerHTML = `<div class="label"><span>${escapeHtml(item.phase)}</span><span>${formatDuration(item.realMs)} · ${formatMinutesValue(item.targetMs)}</span></div><div class="bar"><div class="fill ${item.colorClass}" style="width:${Math.min(100, Math.max(0, width)).toFixed(1)}%;"></div></div><div class="bar-tooltip">${buildTooltipHTML(item.phase, item.realMs, item.targetMs, item.gapMs, item.gapPercent)}</div>`;
+        els.phaseDistribution.appendChild(row);
+      });
+    } else {
+      els.phaseDistribution.innerHTML = '<div class="label-muted">Pas de phase chronométrée</div>';
+    }
+    els.phaseDistributionTarget.textContent = `Cible ${formatMinutesValue(kpi.targetMs)}`;
+
+    els.operatorDistribution.innerHTML = '';
+    if (analysis.operators.length) {
+      analysis.operators.forEach(item => {
+        const row = document.createElement('div');
+        row.className = 'bar-row';
+        row.innerHTML = `<div class="label"><span>${escapeHtml(item.operator)}</span><span>${formatDuration(item.duration)} · ${item.percent}%</span></div><div class="bar"><div class="fill" style="width:${item.percent}%"></div></div>`;
+        els.operatorDistribution.appendChild(row);
+      });
+      els.operatorDistributionTarget.textContent = `${analysis.operators.length} opérateurs`;
+    } else {
+      els.operatorDistribution.innerHTML = '<div class="label-muted">Aucune saisie opérateur</div>';
+      els.operatorDistributionTarget.textContent = '';
+    }
+
+    const prepaNotesHtml = analysis.prepa.notes.length
+      ? `<ul>${analysis.prepa.notes.map(note => `<li>${escapeHtml(note)}</li>`).join('')}</ul>`
+      : '<span class="label-muted">Aucun commentaire</span>';
+    els.prepaSummary.innerHTML = `
+      <div><strong>${analysis.prepa.percent}%</strong> de la checklist complétée</div>
+      <div>Temps total HC: ${formatDuration(analysis.prepa.duration)}</div>
+      <div>Commentaires:<br>${prepaNotesHtml}</div>
+    `;
+
+    if (els.comparisonSessionA && els.comparisonSessionB) {
+      const snapshots = buildSessionSnapshots(phaseComparison);
+      els.comparisonSessionA.innerHTML = '';
+      els.comparisonSessionB.innerHTML = '';
+      snapshots.forEach(item => {
+        const optionA = document.createElement('option');
+        optionA.value = item.id;
+        optionA.textContent = item.label;
+        els.comparisonSessionA.appendChild(optionA);
+        const optionB = document.createElement('option');
+        optionB.value = item.id;
+        optionB.textContent = item.label;
+        els.comparisonSessionB.appendChild(optionB);
+      });
+      if (!snapshots.some(item => item.id === runtime.comparisonA)) runtime.comparisonA = snapshots[0]?.id || '';
+      if (!snapshots.some(item => item.id === runtime.comparisonB)) runtime.comparisonB = snapshots[1]?.id || runtime.comparisonA;
+      els.comparisonSessionA.value = runtime.comparisonA;
+      els.comparisonSessionB.value = runtime.comparisonB;
+      renderComparisonChart(snapshots, timedPhases);
+    }
+  }
+
+  function renderAnalysis() {
+    renderAdvancedAnalysis();
+  }
+
+  function exportAdvancedReport() {
+    const metrics = collectSessionMetrics();
+    const phaseComparison = computePhaseComparison(metrics);
+    const criticalOps = computeCriticalOps(metrics);
+    const perturbateurs = computePerturbateurs(metrics);
+    const kpi = computeKPI(metrics, { phaseComparison, criticalOps });
+    const insights = generateInsights({ kpi, phaseComparison, criticalOps, perturbateurs });
+    const sessionDate = new Date(state.sessionStart).toLocaleString('fr-FR', { hour12: false });
+    const safePo = escapeHtml(state.po || '—');
+    const safeLine = escapeHtml(state.line || '—');
+    const percentLabel = value => Number.isFinite(value) ? value.toFixed(1) : '0.0';
+
+    const lossesHtml = kpi.topLosses.length
+      ? `<ol>${kpi.topLosses.map(item => `<li>${escapeHtml(item.label)} · ${formatDuration(item.gapMs)}</li>`).join('')}</ol>`
+      : '<p>Aucune perte significative.</p>';
+    const phasesRows = phaseComparison.length
+      ? phaseComparison.map(item => `<tr><td>${escapeHtml(item.phase)}</td><td>${formatDuration(item.realMs)}</td><td>${formatMinutesValue(item.targetMs)}</td><td>${item.gapMs >= 0 ? '+' : '−'}${formatDuration(Math.abs(item.gapMs))}</td></tr>`).join('')
+      : '<tr><td colspan="4">Pas de données phase.</td></tr>';
+    const opsRows = criticalOps.length
+      ? criticalOps.slice(0, 8).map(item => `<tr><td>${escapeHtml(item.opName)}</td><td>${escapeHtml(item.phase)}</td><td>${percentLabel(item.gapPercent)}%</td><td>${item.details ? escapeHtml(item.details) : '—'}</td></tr>`).join('')
+      : '<tr><td colspan="4">Aucune opération mesurée.</td></tr>';
+    const perturbHtml = perturbateurs.length
+      ? `<ul>${perturbateurs.map(p => `<li>${escapeHtml(p.label)} – ${p.count}× · ${formatDuration(p.totalMs)}</li>`).join('')}</ul>`
+      : '<p>Pas de perturbateur identifié.</p>';
+    const insightsHtml = insights.length
+      ? `<ul>${insights.map(text => `<li>${escapeHtml(text)}</li>`).join('')}</ul>`
+      : '<p>Pas encore d\'insight.</p>';
+
+    const reportHtml = `<!DOCTYPE html><html lang="fr"><head><meta charset="utf-8"><title>Rapport Analyse SMED</title><style>
+      body{font-family:"Inter","Segoe UI",system-ui,sans-serif;background:#0f1a34;color:#e8eefc;margin:0;padding:32px;}
+      h1,h2{margin:0 0 12px;font-weight:600;}
+      h3{margin:24px 0 12px;font-weight:600;}
+      section{margin-bottom:28px;}
+      .kpi-grid{display:grid;gap:12px;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));}
+      .kpi-card{background:rgba(9,18,40,.85);border-radius:16px;border:1px solid rgba(255,255,255,.12);padding:16px;font-variant-numeric:tabular-nums;}
+      .kpi-card strong{font-size:1.3rem;display:block;margin-bottom:6px;}
+      table{width:100%;border-collapse:collapse;font-size:.9rem;}
+      th,td{padding:10px 12px;border-bottom:1px solid rgba(255,255,255,.12);}
+      .insights{background:rgba(255,183,3,.12);border:1px solid rgba(255,183,3,.35);border-radius:16px;padding:18px;}
+      .meta{color:rgba(232,238,252,.7);font-size:.9rem;margin-bottom:18px;}
+    </style></head><body>
+      <header>
+        <h1>Rapport Analyse SMED</h1>
+        <p class="meta">Session du ${sessionDate} · Ligne ${safeLine} · PO ${safePo}</p>
+      </header>
+      <section>
+        <div class="kpi-grid">
+          <div class="kpi-card"><strong>${formatDuration(kpi.totalMs)}</strong><div>Durée réelle</div><div>Cible ${formatMinutesValue(kpi.targetMs)}</div><div>Écart ${kpi.gapMs >= 0 ? '+' : '−'}${formatDuration(Math.abs(kpi.gapMs))}</div></div>
+          <div class="kpi-card"><strong>${percentLabel(kpi.va.percent)}%</strong><div>Valeur ajoutée</div><div>${formatDuration(kpi.va.ms)}</div></div>
+          <div class="kpi-card"><strong>${percentLabel(kpi.nonVa.percent)}%</strong><div>Non VA</div><div>${formatDuration(kpi.nonVa.ms)}</div></div>
+          <div class="kpi-card"><strong>${percentLabel(kpi.imprevus.percent)}%</strong><div>Imprévus</div><div>${formatDuration(kpi.imprevus.ms)}</div></div>
+        </div>
+      </section>
+      <section>
+        <h2>Top pertes</h2>
+        ${lossesHtml}
+      </section>
+      <section>
+        <h2>Phases – cible vs réel</h2>
+        <table><thead><tr><th>Phase</th><th>Réel</th><th>Cible</th><th>Écart</th></tr></thead><tbody>${phasesRows}</tbody></table>
+      </section>
+      <section>
+        <h2>Opérations critiques</h2>
+        <table><thead><tr><th>Opération</th><th>Phase</th><th>Écart %</th><th>Note</th></tr></thead><tbody>${opsRows}</tbody></table>
+      </section>
+      <section>
+        <h2>Perturbateurs récurrents</h2>
+        ${perturbHtml}
+      </section>
+      <section class="insights">
+        <h2>Insights Kaizen</h2>
+        ${insightsHtml}
+      </section>
+    </body></html>`;
+
+    downloadFile('SMED-rapport-analyse.html', reportHtml, 'text/html');
+    showToast('Rapport 1-page prêt ✓');
+  }
+
+  function buildPhaseTables() {
+    els.phaseTables.innerHTML = '';
+    phaseSections.clear();
+    phasesList.forEach(phase => {
+      const section = document.createElement('section');
+      section.className = 'section-group';
+      const isHC = phase === 'Activité CHGT de PO';
+      section.innerHTML = `
+        <details open>
+          <summary><strong>${phase}</strong> ${isHC ? '<span class="badge hc">HC</span>' : ''}</summary>
+          <div class="batch-actions">
+            <button type="button" class="ghost" data-phase="${phase}" data-action="add">Ajouter une opération</button>
+            <button type="button" class="ghost" data-phase="${phase}" data-action="assign">Définir opérateur</button>
+            <button type="button" class="ghost" data-phase="${phase}" data-action="time">Définir temps</button>
+            <label class="import-group">Importer CSV<input type="file" data-phase="${phase}" accept=".csv"></label>
+            <button type="button" class="ghost" data-phase="${phase}" data-action="export-csv">Exporter CSV</button>
+            <button type="button" class="ghost" data-phase="${phase}" data-action="export-json">Exporter JSON</button>
+          </div>
+          <div class="phase-table-wrapper">
+            <div class="phase-toolbar" data-phase-toolbar></div>
+            <table class="param-table" data-phase="${phase}">
+              <thead>
+                <tr><th title="Inclure cette opération dans le SMED (décocher si non applicable)">Incluse ?</th><th>Opération</th><th>Temps cible (min)</th><th>Opérateur</th><th>Détails (optionnel)</th><th></th></tr>
+              </thead>
+              <tbody></tbody>
+              <tfoot><tr><td colspan="6">Σ ${phase}: <strong class="phase-total">0 min</strong></td></tr></tfoot>
+            </table>
+          </div>
+        </details>
+      `;
+      els.phaseTables.appendChild(section);
+      const toolbar = section.querySelector('[data-phase-toolbar]');
+      const tbody = section.querySelector('tbody');
+      const table = section.querySelector('table');
+      phaseSections.set(phase, { section, table, tbody, toolbar });
+      renderPhaseToolbar(phase);
+      renderPhaseTableBody(phase);
+      updatePhaseTotal(table, phase);
+      section.addEventListener('change', handlePhaseInputChange);
+      section.querySelectorAll('button[data-phase]').forEach(btn => btn.addEventListener('click', handlePhaseAction));
+      const fileInput = section.querySelector('input[type="file"]');
+      fileInput.addEventListener('change', handleImportCsv);
+      enableDragAndDrop(tbody, phase);
+    });
+  }
+
+  function renderPhaseToolbar(phase) {
+    const refs = phaseSections.get(phase);
+    if (!refs || !refs.toolbar) return;
+    const toolbar = refs.toolbar;
+    const config = getPhaseStateConfig(phase);
+    const ops = state.phases[phase] || [];
+    const disabled = ops.length === 0;
+    toolbar.innerHTML = '';
+
+    const sortGroup = document.createElement('div');
+    sortGroup.className = 'phase-toolbar-group';
+    const sortLabel = document.createElement('span');
+    sortLabel.textContent = 'Trier';
+    sortGroup.appendChild(sortLabel);
+    const sortSelect = document.createElement('select');
+    sortSelect.setAttribute('aria-label', 'Trier les opérations de la phase par opérateur');
+    sortSelect.innerHTML = [
+      { value: 'none', label: 'Aucun' },
+      { value: 'op-asc', label: 'Opérateur A→Z' },
+      { value: 'op-desc', label: 'Opérateur Z→A' },
+      { value: 'group', label: 'Regrouper par opérateur' }
+    ].map(option => `<option value="${option.value}">${option.label}</option>`).join('');
+    sortSelect.value = config.sortMode;
+    sortSelect.disabled = disabled;
+    sortSelect.addEventListener('change', event => {
+      config.sortMode = event.target.value;
+      if (config.sortMode !== 'group') {
+        config.allowCrossAssign = false;
+      }
+      refreshPhaseTable(phase);
+    });
+    sortGroup.appendChild(sortSelect);
+    toolbar.appendChild(sortGroup);
+
+    const filterWrapper = document.createElement('div');
+    filterWrapper.className = 'phase-toolbar-group';
+    const filterLabel = document.createElement('span');
+    filterLabel.textContent = 'Filtrer';
+    filterWrapper.appendChild(filterLabel);
+    const chips = document.createElement('div');
+    chips.className = 'phase-filter-chips';
+    const allChip = document.createElement('button');
+    allChip.type = 'button';
+    allChip.className = `phase-filter-chip${config.filterOperator == null ? ' active' : ''}`;
+    allChip.textContent = 'Tous';
+    allChip.disabled = disabled;
+    allChip.addEventListener('click', () => {
+      if (config.filterOperator == null) return;
+      config.filterOperator = null;
+      refreshPhaseTable(phase);
+    });
+    chips.appendChild(allChip);
+    state.operators.forEach((op, idx) => {
+      const chip = document.createElement('button');
+      chip.type = 'button';
+      chip.className = `phase-filter-chip${config.filterOperator != null && normalizeOperatorIndex(config.filterOperator) === normalizeOperatorIndex(idx) ? ' active' : ''}`;
+      chip.textContent = op || `Opérateur n°${idx + 1}`;
+      chip.disabled = disabled;
+      chip.addEventListener('click', () => {
+        const normalized = normalizeOperatorIndex(idx);
+        if (config.filterOperator != null && normalizeOperatorIndex(config.filterOperator) === normalized) {
+          config.filterOperator = null;
+        } else {
+          config.filterOperator = normalized;
+        }
+        refreshPhaseTable(phase);
+      });
+      chips.appendChild(chip);
+    });
+    filterWrapper.appendChild(chips);
+    toolbar.appendChild(filterWrapper);
+
+    const toggleLabel = document.createElement('label');
+    toggleLabel.className = 'phase-toolbar-toggle';
+    const toggleInput = document.createElement('input');
+    toggleInput.type = 'checkbox';
+    toggleInput.checked = !!config.allowCrossAssign;
+    toggleInput.disabled = disabled || config.sortMode !== 'group';
+    toggleInput.setAttribute('aria-label', 'Autoriser le déplacement entre opérateurs (réassignation)');
+    toggleInput.addEventListener('change', event => {
+      config.allowCrossAssign = event.target.checked;
+      refreshPhaseTable(phase);
+    });
+    toggleLabel.appendChild(toggleInput);
+    const toggleText = document.createElement('span');
+    toggleText.textContent = 'Autoriser les déplacements entre opérateurs (réassigne)';
+    toggleLabel.appendChild(toggleText);
+    toolbar.appendChild(toggleLabel);
+  }
+
+  function renderPhaseTableBody(phase) {
+    const refs = phaseSections.get(phase);
+    if (!refs) return;
+    const tbody = refs.tbody;
+    const table = refs.table;
+    if (!tbody || !table) return;
+    const config = getPhaseStateConfig(phase);
+    const operations = (state.phases[phase] || []).slice();
+    let ordered = operations.slice();
+    if (config.sortMode === 'op-asc') {
+      ordered = stableSortByOperatorIndex(operations, true);
+    } else if (config.sortMode === 'op-desc') {
+      ordered = stableSortByOperatorIndex(operations, false);
+    } else if (config.sortMode === 'group') {
+      ordered = stableSortByOperatorIndex(operations, true);
+    }
+    ordered.forEach(operation => {
+      if (!operation.id) operation.id = newId();
+    });
+    const filterIndex = config.filterOperator == null ? null : normalizeOperatorIndex(config.filterOperator);
+    const visibleOps = new Set(applyPhaseFilterForOperator(ordered, filterIndex).map(op => op.id));
+    tbody.innerHTML = '';
+    table.dataset.sortMode = config.sortMode;
+    if (!ordered.length) {
+      return;
+    }
+    if (config.sortMode === 'group') {
+      const groups = groupByOperatorIndex(ordered);
+      groups.forEach((items, operatorIndex) => {
+        const headerRow = document.createElement('tr');
+        headerRow.className = 'op-group-header-row';
+        headerRow.dataset.kind = 'group-header';
+        headerRow.dataset.operatorIndex = operatorIndex;
+        const cell = document.createElement('td');
+        cell.colSpan = 6;
+        cell.className = 'op-group-header';
+        cell.setAttribute('role', 'rowheader');
+        cell.textContent = `Opérateur : ${formatOperatorName(operatorIndex)}`;
+        headerRow.appendChild(cell);
+        if (filterIndex != null && filterIndex !== normalizeOperatorIndex(operatorIndex)) {
+          headerRow.classList.add('is-filtered');
+        }
+        tbody.appendChild(headerRow);
+        items.forEach(operation => {
+          const row = buildPhaseRow(phase, operation);
+          if (!visibleOps.has(operation.id)) {
+            row.classList.add('is-filtered');
+          }
+          tbody.appendChild(row);
+        });
+      });
+    } else {
+      ordered.forEach(operation => {
+        const row = buildPhaseRow(phase, operation);
+        if (!visibleOps.has(operation.id)) {
+          row.classList.add('is-filtered');
+        }
+        tbody.appendChild(row);
+      });
+    }
+  }
+
+  function refreshPhaseTable(phase) {
+    const refs = phaseSections.get(phase);
+    if (!refs) return;
+    renderPhaseToolbar(phase);
+    renderPhaseTableBody(phase);
+    updatePhaseTotal(refs.table, phase);
+  }
+
+  function buildPhaseRow(phase, operation, index) {
+    const tr = document.createElement('tr');
+    tr.draggable = true;
+    const opId = operation.id || newId();
+    operation.id = opId;
+    tr.dataset.id = opId;
+    tr.dataset.kind = 'operation';
+    tr.dataset.operatorIndex = normalizeOperatorIndex(operation.operatorIndex);
+    const enabled = operation.enabled !== false;
+    operation.enabled = enabled;
+    tr.innerHTML = `
+      <td><input type="checkbox" data-field="enabled" title="Inclure cette opération dans le SMED (décocher si non applicable)" ${enabled ? 'checked' : ''}></td>
+      <td><input type="text" data-field="name" value="${escapeHtml(operation.name || '')}"></td>
+      <td><input type="number" step="0.5" min="0" data-field="targetMin" value="${operation.targetMin || 0}"></td>
+      <td><select data-field="operatorIndex"></select></td>
+      <td><textarea data-field="details" placeholder="Checklist, sous-étapes, remarques…">${escapeHtml(operation.details || '')}</textarea></td>
+      <td class="row-tools"><button type="button" class="ghost" data-action="delete">Suppr.</button></td>
+    `;
+    const select = tr.querySelector('select');
+    populateOperatorSelect(select, operation.operatorIndex);
+    tr.querySelector('[data-action="delete"]').addEventListener('click', () => {
+      const idx = state.phases[phase].findIndex(item => item.id === opId);
+      if (idx >= 0) {
+        state.phases[phase].splice(idx,1);
+      }
+      saveState(true);
+      buildPhaseTables();
+      renderOperatorColumns();
+      updateTargets();
+      updateAnalysisDelayed();
+    });
+    return tr;
+  }
+
+  function populateOperatorSelect(select, selectedIndex) {
+    select.innerHTML = '';
+    state.operators.forEach((op, idx) => {
+      if (!op && idx > 0) return;
+      const option = document.createElement('option');
+      option.value = idx;
+      option.textContent = op || `Opérateur ${idx+1}`;
+      if (idx === (typeof selectedIndex === 'number' ? selectedIndex : state.defaultOperatorIndex)) option.selected = true;
+      select.appendChild(option);
+    });
+  }
+
+  function handlePhaseInputChange(event) {
+    const input = event.target;
+    const row = input.closest('tr');
+    if (!row) return;
+    const phase = input.closest('table').dataset.phase;
+    const field = input.dataset.field;
+    const opId = row.dataset.id;
+    if (!field || !opId) return;
+    const idx = state.phases[phase].findIndex(item => item.id === opId);
+    if (idx < 0) return;
+    if (field === 'enabled') {
+      state.phases[phase][idx].enabled = input.checked;
+      saveState();
+      updatePhaseTotal(input.closest('table'), phase);
+      updateTargets();
+      renderOperatorColumns();
+      updateAnalysisDelayed();
+      return;
+    }
+    if (field === 'name') {
+      state.phases[phase][idx][field] = input.value;
+    } else if (field === 'details') {
+      state.phases[phase][idx][field] = input.value;
+    } else {
+      const numeric = Number(input.value);
+      if (field === 'operatorIndex') {
+        state.phases[phase][idx][field] = Number.isFinite(numeric) ? numeric : state.defaultOperatorIndex;
+        row.dataset.operatorIndex = normalizeOperatorIndex(state.phases[phase][idx][field]);
+        saveState();
+        updatePhaseTotal(input.closest('table'), phase);
+        updateTargets();
+        renderOperatorColumns();
+        updateAnalysisDelayed();
+        const selectionStart = typeof input.selectionStart === 'number' ? input.selectionStart : null;
+        const selectionEnd = typeof input.selectionEnd === 'number' ? input.selectionEnd : null;
+        refreshPhaseTable(phase);
+        const refreshedInput = els.phaseTables.querySelector(`tr[data-id="${opId}"] [data-field="operatorIndex"]`);
+        if (refreshedInput) {
+          refreshedInput.focus({ preventScroll: true });
+          if (selectionStart != null && selectionEnd != null && refreshedInput.setSelectionRange) {
+            refreshedInput.setSelectionRange(selectionStart, selectionEnd);
+          }
+        }
+        return;
+      } else {
+        state.phases[phase][idx][field] = Number.isFinite(numeric) ? numeric : 0;
+      }
+    }
+    saveState();
+    updatePhaseTotal(input.closest('table'), phase);
+    updateTargets();
+    renderOperatorColumns();
+    updateAnalysisDelayed();
+  }
+
+  function handlePhaseAction(event) {
+    const btn = event.currentTarget;
+    const phase = btn.dataset.phase;
+    const action = btn.dataset.action;
+    if (action === 'add') {
+      state.phases[phase].push({ id: newId(), name: 'Nouvelle opération', targetMin: 1, operatorIndex: state.defaultOperatorIndex, enabled: true, details: '' });
+      saveState(true);
+      buildPhaseTables();
+      renderOperatorColumns();
+      updateTargets();
+      return;
+    }
+    const table = els.phaseTables.querySelector(`table[data-phase="${phase}"]`);
+    const selected = Array.from(table.querySelectorAll('tbody tr')).filter(row => {
+      const checkbox = row.querySelector('input[data-field="enabled"]');
+      return checkbox ? checkbox.checked : false;
+    });
+    if (action === 'assign') {
+      const operator = prompt('Index opérateur (1-4) :', state.defaultOperatorIndex + 1);
+      const idx = Number(operator) - 1;
+      if (!Number.isInteger(idx) || idx < 0 || idx > 3) return;
+      selected.forEach(row => {
+        const opId = row.dataset.id;
+        if (!opId) return;
+        const rowIndex = state.phases[phase].findIndex(op => op.id === opId);
+        if (rowIndex >= 0) {
+          state.phases[phase][rowIndex].operatorIndex = idx;
+        }
+      });
+      saveState();
+      buildPhaseTables();
+      renderOperatorColumns();
+    }
+    if (action === 'time') {
+      const value = Number(prompt('Temps cible (min) :', 1));
+      if (!Number.isFinite(value)) return;
+      selected.forEach(row => {
+        const opId = row.dataset.id;
+        if (!opId) return;
+        const rowIndex = state.phases[phase].findIndex(op => op.id === opId);
+        if (rowIndex >= 0) {
+          state.phases[phase][rowIndex].targetMin = value;
+        }
+      });
+      saveState();
+      buildPhaseTables();
+      renderOperatorColumns();
+      updateTargets();
+    }
+    if (action === 'export-csv') {
+      const rows = state.phases[phase].map(op => {
+        const operatorIdx = typeof op.operatorIndex === 'number' ? op.operatorIndex : state.defaultOperatorIndex;
+        const operatorLabel = getCurrentOperatorName(operatorIdx || 0);
+        return `${op.name};${op.targetMin};${operatorLabel};${op.enabled === false ? 0 : 1};${sanitizeCsvText(op.details)}`;
+      });
+      const csvContent = ['operation;temps_min;operateur;incluse;details'].concat(rows).join('\n');
+      downloadFile(`phase_${phase.replace(/\s+/g,'_')}.csv`, `\uFEFF${csvContent}`, 'text/csv;charset=utf-8');
+    }
+    if (action === 'export-json') {
+      downloadFile(`phase_${phase.replace(/\s+/g,'_')}.json`, JSON.stringify(state.phases[phase], null, 2), 'application/json');
+    }
+  }
+
+  function handleImportCsv(event) {
+    const input = event.target;
+    const phase = input.dataset.phase;
+    const file = input.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = e => {
+      let text = e.target.result;
+      if (typeof text !== 'string') {
+        text = new TextDecoder('utf-8').decode(text);
+      }
+      if (text.charCodeAt(0) === 0xFEFF) {
+        text = text.slice(1);
+      }
+      const lines = text.split(/\r?\n/).filter(Boolean);
+      const entries = lines.slice(1).map(line => {
+        if (!line.trim()) return null;
+        const parts = line.split(';');
+        const name = parts[0];
+        const time = parts[1];
+        const operator = parts[2];
+        const includedRaw = parts[3];
+        const detailsRaw = parts[4];
+        const cleanedName = (name || '').trim();
+        const numeric = Number.parseFloat((time || '').replace(',', '.'));
+        const operatorLabel = (operator || '').trim().toLowerCase();
+        const matchedIndex = state.operators.findIndex(op => (op || '').trim().toLowerCase() === operatorLabel && operatorLabel);
+        const operatorIndex = matchedIndex >= 0 ? matchedIndex : state.defaultOperatorIndex;
+        const enabled = includedRaw == null ? true : includedRaw.trim() !== '0';
+        return {
+          id: newId(),
+          name: cleanedName || 'Opération',
+          targetMin: Number.isFinite(numeric) ? numeric : 0,
+          operatorIndex,
+          enabled,
+          details: typeof detailsRaw === 'string' ? detailsRaw.replace(/\r/g,'').trim() : ''
+        };
+      }).filter(Boolean);
+      if (entries.length) {
+        state.phases[phase] = entries;
+        saveState(true);
+        buildPhaseTables();
+        renderOperatorColumns();
+        updateTargets();
+        updateAnalysisDelayed();
+      }
+    };
+    reader.readAsText(file, 'utf-8');
+    input.value = '';
+  }
+
+  function updatePhaseTotal(table, phase) {
+    const total = state.phases[phase]
+      .filter(op => op.enabled !== false)
+      .reduce((sum, op) => sum + Number(op.targetMin || 0), 0);
+    const cell = table.querySelector('.phase-total');
+    if (cell) cell.textContent = `${total.toFixed(1)} min`;
+  }
+
+  function enableDragAndDrop(tbody, phase) {
+    let dragged = null;
+    let initialOrder = [];
+
+    const getGroupAnchors = operatorIndex => {
+      const normalized = normalizeOperatorIndex(Number(operatorIndex));
+      const headers = Array.from(tbody.querySelectorAll('tr[data-kind="group-header"]')).filter(row => !row.classList.contains('is-filtered'));
+      const header = headers.find(row => normalizeOperatorIndex(Number(row.dataset.operatorIndex)) === normalized) || null;
+      let nextHeader = null;
+      if (header) {
+        let sibling = header.nextElementSibling;
+        while (sibling) {
+          if (sibling.dataset.kind === 'group-header') {
+            nextHeader = sibling;
+            break;
+          }
+          sibling = sibling.nextElementSibling;
+        }
+      }
+      return { header, nextHeader };
+    };
+
+    tbody.addEventListener('dragstart', event => {
+      const row = event.target.closest('tr[data-kind="operation"]');
+      if (!row) return;
+      dragged = row;
+      initialOrder = state.phases[phase].map(op => op.id);
+      row.classList.add('dragging');
+      event.dataTransfer.effectAllowed = 'move';
+    });
+
+    tbody.addEventListener('dragend', () => {
+      if (dragged) {
+        dragged.classList.remove('dragging');
+      }
+      dragged = null;
+      initialOrder = [];
+    });
+
+    tbody.addEventListener('dragover', event => {
+      if (!dragged) return;
+      const config = getPhaseStateConfig(phase);
+      const draggedOperator = normalizeOperatorIndex(Number(dragged.dataset.operatorIndex));
+      if (config.sortMode === 'group' && !config.allowCrossAssign) {
+        const { header, nextHeader } = getGroupAnchors(draggedOperator);
+        const pointerY = event.clientY;
+        const boundsTop = header ? header.getBoundingClientRect().bottom : tbody.getBoundingClientRect().top;
+        const boundsBottom = nextHeader ? nextHeader.getBoundingClientRect().top : tbody.getBoundingClientRect().bottom;
+        if (pointerY < boundsTop || pointerY > boundsBottom) {
+          event.dataTransfer.dropEffect = 'none';
+          return;
+        }
+        const targetRow = event.target.closest('tr');
+        if (targetRow) {
+          const kind = targetRow.dataset.kind;
+          const targetOperator = normalizeOperatorIndex(Number(targetRow.dataset.operatorIndex));
+          if ((kind === 'operation' || kind === 'group-header') && targetOperator !== draggedOperator) {
+            event.dataTransfer.dropEffect = 'none';
+            return;
+          }
+        }
+      }
+      let selector = 'tr[data-kind="operation"]:not(.dragging):not(.is-filtered)';
+      if (config.sortMode === 'group' && !config.allowCrossAssign) {
+        selector += `[data-operator-index="${draggedOperator}"]`;
+      }
+      const after = getDragAfterElement(tbody, event.clientY, selector);
+      event.preventDefault();
+      event.dataTransfer.dropEffect = 'move';
+      if (!after) {
+        if (config.sortMode === 'group' && !config.allowCrossAssign) {
+          const { nextHeader } = getGroupAnchors(draggedOperator);
+          if (nextHeader) {
+            tbody.insertBefore(dragged, nextHeader);
+          } else {
+            tbody.appendChild(dragged);
+          }
+        } else {
+          tbody.appendChild(dragged);
+        }
+      } else {
+        tbody.insertBefore(dragged, after);
+      }
+    });
+
+    tbody.addEventListener('drop', event => {
+      if (!dragged) return;
+      event.preventDefault();
+      const draggedId = dragged.dataset.id;
+      const config = getPhaseStateConfig(phase);
+      const allowCrossAssign = config.sortMode === 'group' && config.allowCrossAssign;
+      const previousIndices = new Map(state.phases[phase].map(op => [op.id, normalizeOperatorIndex(op.operatorIndex)]));
+      const orderElements = [];
+      let currentOperator = null;
+      Array.from(tbody.children).forEach(child => {
+        if (child.dataset.kind === 'group-header') {
+          currentOperator = normalizeOperatorIndex(Number(child.dataset.operatorIndex));
+        } else if (child.dataset.kind === 'operation') {
+          let effectiveOperator = normalizeOperatorIndex(Number(child.dataset.operatorIndex));
+          if (config.sortMode === 'group' && currentOperator != null) {
+            if (allowCrossAssign) {
+              effectiveOperator = currentOperator;
+            }
+          }
+          orderElements.push({ element: child, operatorIndex: effectiveOperator });
+        }
+      });
+      let reassigned = false;
+      const newState = orderElements.map(({ element, operatorIndex }) => {
+        const normalizedOperator = normalizeOperatorIndex(operatorIndex);
+        const previousOperator = previousIndices.get(element.dataset.id);
+        if (allowCrossAssign && previousOperator != null && previousOperator !== normalizedOperator) {
+          reassigned = true;
+        }
+        element.dataset.operatorIndex = normalizedOperator;
+        const select = element.querySelector('select[data-field="operatorIndex"]');
+        if (select && select.value !== String(normalizedOperator)) {
+          select.value = normalizedOperator;
+        }
+        const enabledInput = element.querySelector('input[data-field="enabled"]');
+        const detailsInput = element.querySelector('[data-field="details"]');
+        return {
+          id: element.dataset.id || newId(),
+          name: element.querySelector('input[data-field="name"]').value,
+          targetMin: Number(element.querySelector('input[data-field="targetMin"]').value) || 0,
+          operatorIndex: normalizedOperator,
+          enabled: enabledInput ? enabledInput.checked : true,
+          details: detailsInput ? detailsInput.value : ''
+        };
+      });
+      const newOrderIds = newState.map(op => op.id);
+      const reordered = newOrderIds.length === initialOrder.length && newOrderIds.some((id, idx) => id !== initialOrder[idx]);
+      dragged.classList.remove('dragging');
+      dragged = null;
+      initialOrder = [];
+      state.phases[phase] = newState;
+      saveState();
+      renderOperatorColumns();
+      updateTargets();
+      updateAnalysisDelayed();
+      refreshPhaseTable(phase);
+      if (reassigned) {
+        const moved = newState.find(op => op.id === draggedId);
+        const targetName = moved ? formatOperatorName(moved.operatorIndex) : formatOperatorName(state.defaultOperatorIndex);
+        showToast(`Opération réassignée à ${targetName} ✓`);
+      }
+      if (reordered) {
+        showToast('Ordre mis à jour ✓');
+      }
+    });
+  }
+
+  function getDragAfterElement(container, y, selector = 'tr[data-kind="operation"]:not(.dragging):not(.is-filtered)') {
+    const draggableElements = [...container.querySelectorAll(selector)];
+    if (!draggableElements.length) return null;
+    return draggableElements.reduce((closest, child) => {
+      const box = child.getBoundingClientRect();
+      const offset = y - box.top - box.height / 2;
+      if (offset < 0 && offset > closest.offset) {
+        return { offset, element: child };
+      } else {
+        return closest;
+      }
+    }, { offset: Number.NEGATIVE_INFINITY, element: null }).element;
+  }
+
+  function buildDefaultsForm() {
+    state.operators.forEach((op, idx) => {
+      if (els.opInputs[idx]) {
+        els.opInputs[idx].value = op;
+      }
+    });
+    els.defaultOperator.innerHTML = '';
+    state.operators.forEach((op, idx) => {
+      if (!op && idx > 0) return;
+      const option = document.createElement('option');
+      option.value = idx;
+      option.textContent = op || `Opérateur ${idx+1}`;
+      if (idx === state.defaultOperatorIndex) option.selected = true;
+      els.defaultOperator.appendChild(option);
+    });
+    els.alertInput.value = state.alertMin;
+    els.multiView.checked = !!state.multiView;
+  }
+
+  function renderEventsList() {
+    if (!els.eventsList) return;
+    els.eventsList.innerHTML = '';
+    const events = state.events.filter(label => label && label.trim());
+    if (!events.length) {
+      const empty = document.createElement('li');
+      empty.className = 'empty';
+      empty.textContent = 'Aucun événement enregistré';
+      els.eventsList.appendChild(empty);
+      return;
+    }
+    events.forEach((label, index) => {
+      const item = document.createElement('li');
+      const span = document.createElement('span');
+      span.textContent = label;
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.dataset.index = index;
+      btn.textContent = 'Suppr.';
+      btn.addEventListener('click', () => removePresetEvent(index));
+      item.append(span, btn);
+      els.eventsList.appendChild(item);
+    });
+  }
+
+  function removePresetEvent(index) {
+    if (!Number.isInteger(index)) return;
+    state.events.splice(index, 1);
+    saveState();
+    renderEventsList();
+    closeQuickEventMenu();
+  }
+
+  function handleEventFormSubmit(event) {
+    event.preventDefault();
+    if (!els.eventInput) return;
+    const value = els.eventInput.value.trim();
+    if (!value) return;
+    state.events.push(value);
+    els.eventInput.value = '';
+    saveState(true);
+    renderEventsList();
+  }
+
+  function updateBrandLine() {
+    if (!els.brandLine) return;
+    const value = (state.line || '').trim();
+    els.brandLine.textContent = value ? value.toUpperCase() : '—';
+  }
+
+  function refreshAll() {
+    els.po.value = state.po;
+    els.mode.value = state.mode;
+    if (els.line) els.line.value = state.line || '';
+    updateBrandLine();
+    renderPhaseChips();
+    renderOperatorColumns();
+    updateTargets();
+    updateDisplay();
+    renderLog();
+    buildPhaseTables();
+    buildDefaultsForm();
+    renderEventsList();
+    renderAnalysis();
+    if (els.start) {
+      const hasStarted = state.marks.some(m => m.kind === 'start');
+      if (state.activePhase === 'Activité CHGT de PO') {
+        els.start.disabled = true;
+        els.start.classList.remove('primary');
+        els.start.classList.add('secondary');
+        els.start.innerHTML = '<span class="icon">▶</span>Démarrer';
+      } else {
+        els.start.classList.add('primary');
+        els.start.classList.remove('secondary');
+        if (hasStarted) {
+          els.start.disabled = true;
+          els.start.innerHTML = 'En cours';
+        } else {
+          els.start.disabled = false;
+          els.start.innerHTML = '<span class="icon">▶</span>Démarrer';
+        }
+      }
+    }
+    if (state.runningSince) {
+      requestTick();
+    } else {
+      cancelAnimationFrame(runtime.animationFrame);
+    }
+  }
+
+  function updateAnalysisDelayed() {
+    clearTimeout(runtime.analysisTimeout);
+    runtime.analysisTimeout = setTimeout(renderAnalysis, 350);
+  }
+
+  function bindEvents() {
+    els.navButtons.forEach(btn => btn.addEventListener('click', () => switchPage(btn.dataset.target, btn)));
+    if (els.line) {
+      els.line.addEventListener('input', () => {
+        state.line = els.line.value;
+        saveState();
+        updateBrandLine();
+      });
+    }
+    if (els.start) {
+      els.start.addEventListener('click', () => {
+        if (state.activePhase === 'Activité CHGT de PO') {
+          showToast('Phase hors chrono : démarrage indisponible', 'info');
+          return;
+        }
+        startTimer();
+      });
+    }
+    // PATCH op-event — libellé bouton global
+    els.lap.innerHTML = '<span class="icon">✦</span>Évènement Hors changement';
+    els.lap.setAttribute('aria-haspopup', 'menu');
+    els.lap.setAttribute('aria-expanded', 'false');
+    els.lap.addEventListener('click', openQuickEventMenu);
+    const openRpt = document.getElementById('openReport');
+    if (openRpt) openRpt.addEventListener('click', () => exportHtml());
+    els.end.addEventListener('click', async () => {
+      const ok = confirm('Confirmer la fin du changement ?');
+      if (!ok) return;
+      await finishChange();
+    });
+    els.reset.addEventListener('click', () => {
+      if (!confirm('Réinitialiser la session ?')) return;
+
+      // 1) Chrono & journal
+      state.marks = [];
+      state.elapsedMs = 0;
+      state.prepaElapsedMs = 0;
+      state.sessionElapsedMs = 0;
+      state.runningSince = null;
+      state.sessionStart = Date.now();
+
+      // 2) Opérations validées -> vidage total
+      state.completedOpsByOp = {};
+      ensureCompletedStructures(); // recrée des Set vides par opérateur/phase
+
+      // 3) Repartir en Prépa (HC) et UI cohérente
+      state.activePhase = 'Activité CHGT de PO';
+      if (els.start) {
+        els.start.disabled = true;
+        els.start.classList.remove('primary');
+        els.start.classList.add('secondary');
+        els.start.innerHTML = '<span class="icon">▶</span>Démarrer';
+      }
+      runtime.focusedOperator = state.defaultOperatorIndex || 0;
+      cancelAnimationFrame(runtime.animationFrame);
+
+      // 4) Sauvegarde + re-render + recentrage opé courante
+      saveState(true);
+      runtime.shouldScrollToCurrent = true;
+      refreshAll();
+    });
+    els.exportCsv.addEventListener('click', exportCsv);
+    els.exportHtml.addEventListener('click', () => exportHtml());
+    els.logTable.addEventListener('input', handleNoteEdit);
+    els.mode.addEventListener('change', () => { state.mode = els.mode.value; saveState(); updateDisplay(); });
+    els.po.addEventListener('input', () => { state.po = els.po.value; saveState(); });
+    els.fullscreen.addEventListener('click', toggleFullscreen);
+    if (els.toggleJournal) {
+      els.toggleJournal.addEventListener('click', () => toggleJournalVisibility());
+    }
+    els.saveParams.addEventListener('click', () => { saveState(true); });
+    els.resetParams.addEventListener('click', () => { if (confirm('Réinitialiser toutes les phases ?')) resetState(); });
+    els.refreshAnalysis.addEventListener('click', renderAnalysis);
+    if (els.exportReportAdvanced) {
+      els.exportReportAdvanced.addEventListener('click', exportAdvancedReport);
+    }
+    if (els.comparisonSessionA) {
+      els.comparisonSessionA.addEventListener('change', () => {
+        runtime.comparisonA = els.comparisonSessionA.value;
+        renderAdvancedAnalysis();
+      });
+    }
+    if (els.comparisonSessionB) {
+      els.comparisonSessionB.addEventListener('change', () => {
+        runtime.comparisonB = els.comparisonSessionB.value;
+        renderAdvancedAnalysis();
+      });
+    }
+    els.alertInput.addEventListener('change', () => { state.alertMin = Number(els.alertInput.value); saveState(); updateTargets(); updateDisplay(); });
+    els.suggestAlert.addEventListener('click', () => {
+      const suggestion = Math.max(0, totalTargetMinutes() * 0.85);
+      const rounded = Math.round(suggestion * 2) / 2;
+      const displayValue = Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+      els.alertInput.value = displayValue;
+      state.alertMin = rounded;
+      saveState(true);
+      updateTargets();
+      updateDisplay();
+    });
+    els.defaultOperator.addEventListener('change', () => {
+      state.defaultOperatorIndex = Number(els.defaultOperator.value);
+      saveState();
+      renderOperatorColumns();
+      renderPhaseChips();
+      updateAnalysisDelayed();
+    });
+    els.opInputs.forEach((input, idx) => {
+      if (!input) return;
+      input.addEventListener('input', () => {
+        const previousName = getCurrentOperatorName(idx);
+        state.operators[idx] = input.value;
+        const newName = getCurrentOperatorName(idx);
+        if (previousName !== newName && state.completedOpsByOp[previousName]) {
+          state.completedOpsByOp[newName] = state.completedOpsByOp[previousName];
+          delete state.completedOpsByOp[previousName];
+        }
+        if (previousName !== newName) {
+          state.marks.forEach(mark => {
+            if (mark.operator === previousName) {
+              mark.operator = newName;
+            }
+          });
+        }
+        ensureCompletedStructures();
+        saveState();
+        buildDefaultsForm();
+        renderOperatorColumns();
+      });
+    });
+    els.multiView.addEventListener('change', () => {
+      state.multiView = els.multiView.checked;
+      saveState();
+      renderOperatorColumns();
+    });
+    if (els.eventForm) {
+      els.eventForm.addEventListener('submit', handleEventFormSubmit);
+    }
+    // PATCH rm-toggle: suppression du toggle "seulement la courante"
+    // PATCH SMED — undo dernière validation
+    const undoBtn = document.getElementById('undoLast');
+    if (undoBtn){
+      undoBtn.addEventListener('click', ()=>{
+        // dernière marque d'opération (kind === 'op') dans la phase active pour l'opérateur focalisé
+        const opName = getCurrentOperatorName(runtime.focusedOperator);
+        for (let i = state.marks.length - 1; i >= 0; i--){
+          const m = state.marks[i];
+          if (m.kind === 'op' && m.operator === opName && m.phase === state.activePhase){
+            // retirer du set "complété"
+            ensureCompletedStructures();
+            state.completedOpsByOp[opName][state.activePhase].delete(m.opId || m.label);
+            // supprimer la marque
+            state.marks.splice(i,1);
+            saveState(true);
+            renderOperatorColumns();
+            renderLog();
+            updateAnalysisDelayed();
+            showToast('Dernière opération annulée');
+            return;
+          }
+        }
+        showToast('Rien à annuler', 'info');
+      });
+    }
+    document.addEventListener('keydown', handleShortcuts);
+  }
+
+  function toggleJournalVisibility(force) {
+    const shouldHide = typeof force === 'boolean' ? force : !runtime.journalHidden;
+    runtime.journalHidden = shouldHide;
+    document.body.classList.toggle('journal-hidden', runtime.journalHidden);
+    if (els.toggleJournal) {
+      els.toggleJournal.setAttribute('aria-pressed', runtime.journalHidden ? 'true' : 'false');
+      els.toggleJournal.title = 'Afficher/Masquer Journal';
+      els.toggleJournal.innerHTML = `<span class="icon">🗂</span>${runtime.journalHidden ? 'Afficher le journal' : 'Masquer le journal'}`;
+    }
+  }
+
+  function toggleFullscreen() {
+    if (!document.fullscreenElement) {
+      document.documentElement.requestFullscreen().catch(() => showToast('Impossible de passer en plein écran', 'error'));
+    } else {
+      document.exitFullscreen();
+    }
+  }
+
+  function hideSplash(immediate) {
+    if (!els.splash) return;
+    const splashNode = els.splash;
+    const cleanup = () => {
+      document.body.classList.remove('splash-lock');
+      if (splashNode && splashNode.parentNode) {
+        splashNode.parentNode.removeChild(splashNode);
+      }
+      if (els.splash === splashNode) {
+        els.splash = null;
+      }
+    };
+    splashNode.setAttribute('aria-hidden', 'true');
+    if (immediate) {
+      cleanup();
+      return;
+    }
+    splashNode.classList.add('is-hiding');
+    setTimeout(cleanup, 600);
+  }
+
+  function initSplashScreen() {
+    setupLogoContainer(document.querySelector('.brand-mark.logo-container'));
+
+    if (!els.splash) return;
+
+    setupLogoContainer(document.querySelector('.splash-logo-wrap'));
+
+    let seen = false;
+    try {
+      seen = sessionStorage.getItem('smed_splash_seen') === '1';
+    } catch (err) {
+      seen = false;
+    }
+    if (seen) {
+      hideSplash(true);
+      return;
+    }
+    try {
+      sessionStorage.setItem('smed_splash_seen', '1');
+    } catch (err) {
+      /* ignore */
+    }
+
+    document.body.classList.add('splash-lock');
+
+    const tasks = [];
+    const preload = new Image();
+    preload.src = 'smed-logo.png';
+    if (typeof preload.decode === 'function') {
+      tasks.push(preload.decode().catch(() => {}));
+    } else {
+      tasks.push(new Promise(resolve => {
+        if (preload.complete) {
+          resolve();
+        } else {
+          preload.addEventListener('load', () => resolve(), { once: true });
+          preload.addEventListener('error', () => resolve(), { once: true });
+        }
+      }));
+    }
+
+    if (document.fonts && document.fonts.ready) {
+      tasks.push(document.fonts.ready.catch(() => {}));
+    }
+
+    tasks.push(new Promise(resolve => setTimeout(resolve, 2600)));
+
+    Promise.all(tasks).then(() => hideSplash(false)).catch(() => hideSplash(false));
+  }
+
+  function handleShortcuts(event) {
+    if (event.target && ['INPUT','TEXTAREA','SELECT'].includes(event.target.tagName)) return;
+    if (event.key.toLowerCase() === 'l') {
+      event.preventDefault();
+      els.lap.click();
+    }
+    if (event.key.toLowerCase() === 'j') {
+      event.preventDefault();
+      toggleJournalVisibility();
+    }
+    if (['1','2','3','4'].includes(event.key)) {
+      runtime.focusedOperator = Number(event.key) - 1;
+      renderOperatorColumns();
+    }
+  }
+
+  function switchPage(pageId, btn) {
+    closeQuickEventMenu();
+    runtime.activePage = pageId;
+    els.pages.forEach(page => page.classList.toggle('active', page.id === pageId));
+    els.navButtons.forEach(nav => {
+      const active = nav === btn;
+      nav.classList.toggle('active', active);
+      nav.setAttribute('aria-selected', active ? 'true' : 'false');
+    });
+    renderAnalysis();
+  }
+
+  function updateClock() {
+    els.now.textContent = new Date().toLocaleString('fr-FR', { hour12: false });
+    requestAnimationFrame(updateClock);
+  }
+
+  bindEvents();
+  initSplashScreen();
+  toggleJournalVisibility(runtime.journalHidden);
+  refreshAll();
+  updateClock();
+  renderAnalysis();
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a per-phase toolbar with sorting modes, operator filter chips, and a reassignment toggle for the parameters tables
- introduce helper utilities to format operator names, sort stably by operator, and group/filter operations before rendering
- update drag-and-drop handling to respect operator groups, support cross-group reassignment with persistence, and emit toasts

## Testing
- Manual UI check via Playwright browser (see attached screenshot)


------
https://chatgpt.com/codex/tasks/task_e_68e3d85709d0832da1cb383232ad0be8